### PR TITLE
fixed closure type inferrence in generic call context

### DIFF
--- a/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericParameterInferrer.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericParameterInferrer.cs
@@ -197,7 +197,10 @@ namespace Boo.Lang.Compiler.TypeSystem.Generics
 
 				if (CanResolveClosure(closure))
 				{
-					ResolveClosure(this, closure, argument.FormalType as ICallableType);
+					var callable = (ICallableType)argument.FormalType;
+					if (closure.Parameters.Count != callable.GetSignature().Parameters.Length)
+						continue;
+					ResolveClosure(this, closure, callable);
 					_closureDependencies.Remove(closure);
 					Infer(argument.FormalType, closure.ExpressionType);
 				}

--- a/tests/BooCompiler.Tests/BooCompiler.Tests.csproj
+++ b/tests/BooCompiler.Tests/BooCompiler.Tests.csproj
@@ -128,7 +128,7 @@
     <Compile Include="BooTestCaseUtil.cs" />
     <Compile Include="CallablesIntegrationTestFixture.cs" />
     <Compile Include="ClosuresIntegrationTestFixture.cs" />
-    <Compile Include="ClrextensionsIntegrationTestFixture.cs" />
+    <Compile Include="ClrExtensionsIntegrationTestFixture.cs" />
     <Compile Include="ClrIntegrationTestFixture.cs" />
     <Compile Include="CompilerContextTest.cs" />
     <Compile Include="CompilerErrorFactoryTest.cs" />

--- a/tests/BooCompiler.Tests/ClrextensionsIntegrationTestFixture.cs
+++ b/tests/BooCompiler.Tests/ClrextensionsIntegrationTestFixture.cs
@@ -19,6 +19,12 @@ namespace BooCompiler.Tests
 		}
 		
 		[Test]
+		public void infer_closure_singature()
+		{
+			RunCompilerTestCase(@"infer-closure-singature.boo");
+		}
+		
+		[Test]
 		public void linq_extensions_1()
 		{
 			RunCompilerTestCase(@"linq-extensions-1.boo");

--- a/tests/testcases/integration/clrextensions/infer-closure-singature.boo
+++ b/tests/testcases/integration/clrextensions/infer-closure-singature.boo
@@ -1,0 +1,6 @@
+"""
+0 -1
+"""
+import System.Linq.Enumerable
+
+print join(("1", "2").Select({s|s.IndexOf("1")}).ToArray())


### PR DESCRIPTION
This is not ideal solution, compiler infer method signature two times first than select ambiguous (ProcessMethodBodies.cs line 4144) second than process method call (ProcessMethodBodies.cs line 4449)
it should be in one place, but code base is too complex for me for now. 
It`s work, all tests passed and not ideal solution better than nothing.
Still broken:
closure type inference in constructor, I will try to fix it shortly
linq-extensions-2.boo parser think that in {i | i} body is method call
