### PR TITLE
Assembly Evidence support for Partial Trust

### DIFF
--- a/src/Boo.Lang.Compiler/CompilerParameters.cs
+++ b/src/Boo.Lang.Compiler/CompilerParameters.cs
@@ -33,6 +33,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Security.Policy;
 using System.Text.RegularExpressions;
 using Boo.Lang.Compiler.Ast;
 using Boo.Lang.Compiler.Util;
@@ -64,6 +65,8 @@ namespace Boo.Lang.Compiler
 		private string _outputAssembly;
 
 		private CompilerOutputType _outputType;
+		
+		private Evidence _evidence;
 
 		private bool _debug;
 
@@ -444,6 +447,16 @@ namespace Boo.Lang.Compiler
 			get { return _outputType; }
 
 			set { _outputType = value; }
+		}
+
+		/// <summary>
+		/// The evidence to assign to the resulting in-memory assembly
+		/// </summary>
+		public Evidence Evidence
+		{
+			get { return _evidence; }
+
+			set { _evidence = value; }
 		}
 
 		public bool GenerateInMemory

--- a/src/Boo.Lang.Compiler/Steps/EmitAssembly.cs
+++ b/src/Boo.Lang.Compiler/Steps/EmitAssembly.cs
@@ -5430,8 +5430,8 @@ namespace Boo.Lang.Compiler.Steps
 			var assemblyBuilderAccess = GetAssemblyBuilderAccess();
 			var targetDirectory = GetTargetDirectory(outputFile);
 			_asmBuilder = string.IsNullOrEmpty(targetDirectory)
-				? AppDomain.CurrentDomain.DefineDynamicAssembly(asmName, assemblyBuilderAccess)
-				: AppDomain.CurrentDomain.DefineDynamicAssembly(asmName, assemblyBuilderAccess, targetDirectory);
+				? AppDomain.CurrentDomain.DefineDynamicAssembly(asmName, assemblyBuilderAccess, Parameters.Evidence)
+				: AppDomain.CurrentDomain.DefineDynamicAssembly(asmName, assemblyBuilderAccess, targetDirectory, Parameters.Evidence);
 
 			if (Parameters.Debug)
 			{

--- a/tests/Boo.Lang.PatternMatching.Tests/MatchMacroTest.boo
+++ b/tests/Boo.Lang.PatternMatching.Tests/MatchMacroTest.boo
@@ -7,7 +7,7 @@ class Container[of T]:
 	public value as T
 	
 class Collection:
-	public Items as List
+	public Items as Boo.Lang.List
 	
 [TestFixture]
 class MatchMacroTest:

--- a/tests/Boo.Lang.Useful.Tests/Collections/CacheTestFixture.boo
+++ b/tests/Boo.Lang.Useful.Tests/Collections/CacheTestFixture.boo
@@ -85,7 +85,7 @@ class CacheTextFixture:
 	[Test]
 	def Keys():
 		AddThreeValues()
-		coll= cache.Keys as List
+		coll= cache.Keys as Boo.Lang.List
 		assert coll[0] == 3
 		assert coll[1] == 2
 		assert coll[2] == 1
@@ -93,7 +93,7 @@ class CacheTextFixture:
 		s = cache[2] as string #put 2 in front
 		assert s == "two"
 		
-		coll= cache.Keys as List
+		coll= cache.Keys as Boo.Lang.List
 		assert coll[0] == 2
 		assert coll[1] == 3
 		assert coll[2] == 1
@@ -101,7 +101,7 @@ class CacheTextFixture:
 	[Test]	
 	def Values():
 		AddThreeValues()
-		coll= cache.Values as List
+		coll= cache.Values as Boo.Lang.List
 		assert coll[0] == "three"
 		assert coll[1] == "two"
 		assert coll[2] == "one"
@@ -109,7 +109,7 @@ class CacheTextFixture:
 		s = cache[2] as string #put 2 in front
 		assert s == "two"
 		
-		coll= cache.Values as List
+		coll= cache.Values as Boo.Lang.List
 		assert coll[0] == "two"
 		assert coll[1] == "three"
 		assert coll[2] == "one"

--- a/tests/BooCompiler.Tests/AssemblyEvidenceTest.cs
+++ b/tests/BooCompiler.Tests/AssemblyEvidenceTest.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Security;
+using System.Security.Policy;
+using Boo.Lang.Compiler;
+using Boo.Lang.Compiler.Ast;
+using Boo.Lang.Compiler.IO;
+using NUnit.Framework;
+
+namespace BooCompiler.Tests
+{
+	[TestFixture]
+	public class AssemblyEvidenceTest : AbstractCompilerTestCase
+	{
+		[Test]
+		public void DynamicAssemblyReceivesDefaultPermissions()
+		{
+			CompilerContext compilerContext;
+			
+			_parameters.Evidence = null;
+			_parameters.Input.Add(new StringInput("<teststring>", "test = 1"));
+			
+			Run(null, out compilerContext);
+			
+			// The newly created Evidence for the assembly will be different from the creator as it only copies the grant sets.
+			// Eg: The Compiler Evidence will have a StrongName Hash, the new assembly will not.
+			// In other words, the Evidence objects will be different, but will have the same effective permissions.
+			// Thus we use SecurityManager.ResolvePolicy to get the PermissionSets for each assembly and compare them.
+			Assert.AreEqual(
+				SecurityManager.ResolvePolicy(typeof(CompilerParameters).Assembly.Evidence),
+				SecurityManager.ResolvePolicy(compilerContext.GeneratedAssembly.Evidence),
+				"Resulting Assembly has different permissions than expected"
+			);
+		}
+		
+		[Test]
+		public void DynamicAssemblyReceivesPassedEvidence()
+		{
+			CompilerContext compilerContext;
+			Evidence internetEvidence;
+			
+			// Create the test assembly in the Internet Zone
+			internetEvidence = new Evidence(new object[] { new Zone(SecurityZone.Internet) }, new object[] { });
+			
+			_parameters.Evidence = internetEvidence;
+			_parameters.Input.Add(new StringInput("<teststring>", "test = 1"));
+			
+			Run(null, out compilerContext);
+			
+			// As we provided Evidence, it should be exactly the same as the one we passed in.
+			// Thus the test is stricter than simply checking the resulting PermissionSet via SecurityManager.ResolvePolicy
+			Assert.AreEqual(internetEvidence, compilerContext.GeneratedAssembly.Evidence, "Evidence is not what was passed");
+		}
+		
+		protected override bool VerifyGeneratedAssemblies
+		{
+			get
+			{
+				return false; // Testing in-memory assemblies only
+			}
+		}
+	}
+}

--- a/tests/testcases/integration/callables/callables-17.boo
+++ b/tests/testcases/integration/callables/callables-17.boo
@@ -12,7 +12,7 @@ def hyphenate(fn as ICallable):
 def upper(fn as ICallable):
 	return fn().ToString().ToUpper()
 	
-def test(expectedValues as List, decorator as ICallable):
+def test(expectedValues as Boo.Lang.List, decorator as ICallable):
 	Assert.AreEqual(expectedValues[0], decorator(foo))
 	Assert.AreEqual(expectedValues[1], decorator(bar))
 	

--- a/tests/testcases/stdlib/hash-1.boo
+++ b/tests/testcases/stdlib/hash-1.boo
@@ -2,8 +2,8 @@ import NUnit.Framework
 
 h = Hash((i, i*2) for i in range(5))
 Assert.AreEqual(5, len(h))
-Assert.AreEqual([0, 1, 2, 3, 4], List(h.Keys).Sort())
-Assert.AreEqual([0, 2, 4, 6, 8], List(h.Values).Sort())
+Assert.AreEqual([0, 1, 2, 3, 4], Boo.Lang.List(h.Keys).Sort())
+Assert.AreEqual([0, 2, 4, 6, 8], Boo.Lang.List(h.Values).Sort())
 
 for i in range(5):
 	Assert.AreEqual(i*2, h[i])


### PR DESCRIPTION
This adds evidence support to dynamic assemblies, allowing the resulting in-memory assembly to run under partial trust. Comes with a few tests to ensure it works properly, and a few fixes to the tests against the latest NUnit that cause namespace collisions.

Took me a while to get back to this. I hope the changes are acceptable.
