### PR TITLE
workaround for code generation problem around CodeSnippetTypeMember on MS.NET

### DIFF
--- a/src/Boo.Lang.CodeDom/BooCodeGenerator.boo
+++ b/src/Boo.Lang.CodeDom/BooCodeGenerator.boo
@@ -64,8 +64,18 @@ class BooCodeGenerator(CodeGenerator):
 		get:
 			return "null"	
 
+	// workaround for MS's implementation around code snippets
+	protected BooIndent as int:
+		get:
+			return _booIndent
+		set:
+			_booIndent = value
+			Indent = value
+	_booIndent = 0
+
 	protected override def OutputType(typeRef as CodeTypeReference):
 		Output.Write(GetTypeOutput(typeRef))
+
 
 	protected override def GenerateArrayCreateExpression(exp as CodeArrayCreateExpression) :
 		if exp.Initializers is not null and exp.Size == 0 and exp.SizeExpression is null:
@@ -298,20 +308,20 @@ class BooCodeGenerator(CodeGenerator):
 	protected override def GenerateSnippetMember(e as CodeSnippetTypeMember) :
 		if e.CustomAttributes:
 			OutputAttributes(e.CustomAttributes, null, false)
-		Output.WriteLine(FixIndent(e.Text, Options.IndentString, Indent, false))
+		Output.WriteLine(FixIndent(e.Text, Options.IndentString, BooIndent, false))
 	
 	protected override def GenerateSnippetExpression(e as CodeSnippetExpression) :
 		//Output.Write("("+e.Value+")")
 		Output.Write(e.Value)
 		
 	protected override def GenerateSnippetCompileUnit(e as CodeSnippetCompileUnit) :
-		Output.WriteLine(FixIndent(e.Value, Options.IndentString, Indent, false))
+		Output.WriteLine(FixIndent(e.Value, Options.IndentString, BooIndent, false))
 		
 	protected override def GenerateSnippetStatement(e as CodeSnippetStatement) :
 		if _NET_2_0:
 			Output.WriteLine(e.Value)
 		else:
-			Output.WriteLine(FixIndent(e.Value, Options.IndentString, Indent, false))
+			Output.WriteLine(FixIndent(e.Value, Options.IndentString, BooIndent, false))
 		
 	protected override def GenerateEntryPointMethod(e as CodeEntryPointMethod, c as CodeTypeDeclaration) :
 		Method(e, "Main")
@@ -684,13 +694,13 @@ class BooCodeGenerator(CodeGenerator):
 		
 	protected virtual def BeginBlock():
 		Output.WriteLine(":")
-		++Indent
+		++BooIndent
 		
 	protected virtual def EndBlock():
 		EndBlock(true)
 		
 	protected virtual def EndBlock(realend as bool):
-		--Indent
+		--BooIndent
 		if realend:
 			End()
 			

--- a/tests/Boo.Lang.CodeDom.Tests/CodeGeneratorTestFixture.boo
+++ b/tests/Boo.Lang.CodeDom.Tests/CodeGeneratorTestFixture.boo
@@ -195,6 +195,33 @@ class CodeGeneratorTestFixture:
 		
 		result = Boo.Lang.CodeDom.BooCodeGenerator.FixIndent(code, "    ", 2, false)
 		AssertEqualsIgnoringNewLines expected, result
+
+	[Test]
+	def CodeSnippetTypeMemberTest():
+		compileUnit = CodeCompileUnit()
+		nspace = CodeNamespace("TestNamespace")
+		compileUnit.Namespaces.Add(nspace)
+		cls = CodeTypeDeclaration("Test", IsClass: true)
+		mem = CodeSnippetTypeMember()
+		mem.Text = """
+def TestFunc():
+	pass
+"""
+		cls.Members.Add(mem)
+		nspace.Types.Add(cls)
+
+		codegen = BooCodeGenerator()
+		expected = """namespace TestNamespace
+
+
+class Test:
+    
+
+    def TestFunc():
+        pass
+"""
+
+		AssertCompileUnitIgnoringComments expected, compileUnit
 		
 	def AssertEqualsIgnoringNewLines(expected as string, actual as string):
 		Assert.AreEqual(NormalizeNewLines(expected), NormalizeNewLines(actual))


### PR DESCRIPTION
Hi,
I've found current Boo.Lang.CodeDom.BooCodeGenerator outputs improper (indent breaked) Boo code
when using System.CodeDom.CodeSnippetTypeMember on Microsoft .NET Framework. (I've checked on 4.0)

Using CodeSnippetTypeMember, Microsoft's implementation of System.CodeDom.Compiler.CodeGenerator (the base class of BooCodeGenerator) seems to call BooCodeGenerator.GenerateSnippetMember() with Indent property set to 0 (ignoring previously assigned Indent value), so BooCodeGenerator.FixIndent() doesn't work properly, and finally BooCodeGenerator outputs improper code.

I've written the test code and the workaround for this problem. please check it.

Thanks.
