### PR TITLE
Changes to default.build file

### DIFF
--- a/default.build
+++ b/default.build
@@ -20,9 +20,13 @@
 	<property name="skip.antlr" value="False" />
 	<property name="skip.ast" value="False" />
 	<property name="skip.vs" value="False" />
+
+	<property name="gsv.name" value="gtksourceview-1.0" />
 	
 	<property name="build.dir" value="build" dynamic="True"/>
 	<property name="distrobuild.dir" value="distrobuild"/>
+	<property name="docs.dir" valuel="docs" />
+	<property name="examples.dir" valuel="examples" />
 
 	<property name="install.prefix" value="/usr/local" />
 	<property name="install.destdir" value="/" />
@@ -30,9 +34,15 @@
 	<property name="install.share" value="${path::combine(install.prefix,'share')}" />
 	<property name="install.bindir" value="${path::combine(install.prefix,'bin')}" />
 	<property name="install.libdir" value="${path::combine(install.prefix,'lib')}" />
+	<property name="install.docsdir" value="${path::combine(install.prefix, docs.dir)}" />
+	<property name="install.examplesdir" value="${path::combine(install.prefix, examples.dir)}" />
 	<property name="install.boolib" value="${path::combine(install.libdir,'boo')}" />
+	<property name="install.boodocs" value="${path::combine(install.docsdir,'boo')}" />
+	<property name="install.booexamples" value="${path::combine(install.examplesdir,'boo')}" />
 
 	<property name="fakeroot.boolib" value="${install.destdir}/${install.boolib}" />
+	<property name="fakeroot.boodocs" value="${install.destdir}/${install.boodocs}" />
+	<property name="fakeroot.booexamples" value="${install.destdir}/${install.booexamples}" />
 	<property name="fakeroot.bindir" value="${install.destdir}/${install.bindir}" />
 	<property name="fakeroot.libdir" value="${install.destdir}/${install.libdir}" />
 	<property name="fakeroot.share" value="${install.destdir}/${install.share}" />
@@ -479,6 +489,7 @@
 		</booc>
 	</target>
 	
+
 	<target name="Boo.Lang.Compiler" depends="Boo.Lang, Boo.Lang.Ast">
 		<csc target="library"
 			output="${build.dir}/Boo.Lang.Compiler.dll"
@@ -557,7 +568,7 @@
 
 		<property name="sharedmime.prefix" value="${pkg-config::get-variable('shared-mime-info','prefix')}" />
 		<property name="fakeroot.sharedmime" value="${install.destdir}/${sharedmime.prefix}" />
-		<property name="gsv.prefix" value="${pkg-config::get-variable('gtksourceview-1.0','prefix')}" />
+		<property name="gsv.prefix" value="${pkg-config::get-variable(gsv.name,'prefix')}" />
 		<property name="fakeroot.gsv" value="${install.destdir}/${gsv.prefix}" />
 
 		<mkdir dir="${fakeroot.boolib}"/>
@@ -612,13 +623,38 @@
 			</fileset>
 		</copy>
 		
-		<copy file="extras/boo.lang" todir="${fakeroot.gsv}/share/gtksourceview-1.0/language-specs/" />
+		<copy file="extras/boo.lang" todir="${fakeroot.gsv}/share/${gsv.name}/language-specs/" />
 		<copy file="${build.dir}/boo.pc" todir="${fakeroot.libdir}/pkgconfig/" />
 		<copy file="extras/boo-mime-info.xml" todir="${fakeroot.sharedmime}/share/mime/packages/" />
 
 		<exec program="chmod" commandline="+x ${fakeroot.bindir}/booc" />
 		<exec program="chmod" commandline="+x ${fakeroot.bindir}/booi" />
 		<exec program="chmod" commandline="+x ${fakeroot.bindir}/booish" />
+
+		<!-- Copy over documentation -->
+		<mkdir dir="${fakeroot.boodocs}"/>
+		
+		<copy todir="${fakeroot.boodocs}">
+			<fileset basedir="${docs.dir}">
+				<include name="*.sxw" />
+			</fileset>
+		</copy>
+
+		<copy todir="${fakeroot.boodocs}">
+			<fileset basedir=".">
+				<include name="*.txt" />
+			</fileset>
+		</copy>
+
+		<!-- Copy over examples -->
+		<mkdir dir="${fakeroot.booexamples}"/>
+
+		<copy todir="${fakeroot.booexamples}">
+			<fileset basedir="${examples.dir}">
+				<include name="**" />
+			</fileset>
+		</copy>
+
 	</target>
 
 	<target name="install-win32" depends="all">
@@ -670,7 +706,7 @@
 
 		<property name="sharedmime.prefix" value="${pkg-config::get-variable('shared-mime-info','prefix')}" />
 		<property name="fakeroot.sharedmime" value="${install.destdir}/${sharedmime.prefix}" />
-		<property name="gsv.prefix" value="${pkg-config::get-variable('gtksourceview-1.0','prefix')}" />
+		<property name="gsv.prefix" value="${pkg-config::get-variable(gsv.name,'prefix')}" />
 		<property name="fakeroot.gsv" value="${install.destdir}/${gsv.prefix}" />
 		
 		<foreach item="File" property="filename">
@@ -690,10 +726,12 @@
 		</foreach>
 		
 		<delete dir="${fakeroot.boolib}" />
+		<delete dir="${fakeroot.boodocs}" />
+		<delete dir="${fakeroot.booexamples}" />
 		
 		<delete file="${fakeroot.sharedmime}/share/mime-info/boo.keys" />
 		<delete file="${fakeroot.sharedmime}/share/mime-info/boo.mime" />
-		<delete file="${fakeroot.gsv}/share/gtksourceview-1.0/language-specs/boo.lang" />
+		<delete file="${fakeroot.gsv}/share/${gsv.name}/language-specs/boo.lang" />
 		<delete file="${fakeroot.libdir}/pkgconfig/boo.pc" />
 		<delete file="${fakeroot.sharedmime}/share/mime/packages/boo-mime-info.xml" />
 		<delete file="${fakeroot.bindir}/booi" />
@@ -737,6 +775,7 @@
 				<include name="**/*.cs" />
 				<include name="**/*.boo" />
 				<exclude name="Boo.Lang.Parser/antlr/**" />
+
 			</fileset>
 			<fileset basedir="examples">
 				<include name="**/*.boo" />


### PR DESCRIPTION
The only major change is the addition of copying the docs and examples over during an install on linux/bsd platforms.  Thought it would be good to include such files during an install since they do benefit the user. Also added gsv.name property since the platform I am working on (OpenBSD) uses 2.0 instead of 1.0.

My commit message:
Added gsv.name property to identify the gtsourceview version as some distros may be using 2.0. Added {install,fakeroot}.boo{docs,examples} properties to identify the appropriate docs and examples target directories.  Updated the install-linux target to copy over the docs and examples for easier reference.

Please let me know if you have questions/comments.

Thanks,
Ryan
