### PR TITLE
fakeroot property in default.build

### DIFF
--- a/default.build
+++ b/default.build
@@ -40,6 +40,7 @@
 	<property name="install.boodocs" value="${path::combine(install.docsdir,'boo')}" />
 	<property name="install.booexamples" value="${path::combine(install.examplesdir,'boo')}" />
 
+	<property name="fakeroot" value="${install.destdir}" />
 	<property name="fakeroot.boolib" value="${install.destdir}/${install.boolib}" />
 	<property name="fakeroot.boodocs" value="${install.destdir}/${install.boodocs}" />
 	<property name="fakeroot.booexamples" value="${install.destdir}/${install.booexamples}" />
@@ -567,9 +568,9 @@
 		-->
 
 		<property name="sharedmime.prefix" value="${pkg-config::get-variable('shared-mime-info','prefix')}" />
-		<property name="fakeroot.sharedmime" value="${install.destdir}/${sharedmime.prefix}" />
+		<property name="fakeroot.sharedmime" value="${fakeroot}/${sharedmime.prefix}" />
 		<property name="gsv.prefix" value="${pkg-config::get-variable(gsv.name,'prefix')}" />
-		<property name="fakeroot.gsv" value="${install.destdir}/${gsv.prefix}" />
+		<property name="fakeroot.gsv" value="${fakeroot}/${gsv.prefix}" />
 
 		<mkdir dir="${fakeroot.boolib}"/>
 		<mkdir dir="${fakeroot.bindir}"/>
@@ -705,9 +706,9 @@
 		-->
 
 		<property name="sharedmime.prefix" value="${pkg-config::get-variable('shared-mime-info','prefix')}" />
-		<property name="fakeroot.sharedmime" value="${install.destdir}/${sharedmime.prefix}" />
+		<property name="fakeroot.sharedmime" value="${fakeroot}/${sharedmime.prefix}" />
 		<property name="gsv.prefix" value="${pkg-config::get-variable(gsv.name,'prefix')}" />
-		<property name="fakeroot.gsv" value="${install.destdir}/${gsv.prefix}" />
+		<property name="fakeroot.gsv" value="${fakeroot}/${gsv.prefix}" />
 		
 		<foreach item="File" property="filename">
 		<in>


### PR DESCRIPTION
Hi again,

I'm still working on porting boo to OpenBSD (almost there) however I ran into a small snag with the way OpenBSD fakes the installation.  Currently, during the fake installation, some of the mime-info files get copied to the actual filesystem instead of the fake system.  All I did was add a new property (fakeroot) that is initialized with the value in the install.destdir property that is used to create the sharedmime.prefix and fakeroot.gsv properties during install.  If you could please at least evaluate this diff and see what I am going for, it would be greatly appreciated.  if you have a better suggested approach, I would be more than interested into hearing it.

Commit msg:
Added property to account for the shared-mime-info files being copied to the appropriate place.  Needed for OpenBSD fake install

Thanks,
Ryan
