### PR TITLE
Removed '/pt' directory copy task from build file.

### DIFF
--- a/default.build
+++ b/default.build
@@ -603,12 +603,6 @@
 		</do>
 		</foreach>
 		
-		<copy todir="${fakeroot.boolib}/pt">
-			<fileset basedir="${build.dir}/pt">
-				<include name="*"/>
-			</fileset>
-		</copy>
-
 		<copy todir="${fakeroot.bindir}">
 			<fileset basedir="${build.dir}">
 				<include name="booc"/>


### PR DESCRIPTION
The pt directory doesn't seem to exist in source and NAnt 0.92 errors during installation because of this.
