### PR TITLE
Fix for empty array pattern matching.

### DIFF
--- a/src/Boo.Lang.PatternMatching/Impl/PatternExpander.boo
+++ b/src/Boo.Lang.PatternMatching/Impl/PatternExpander.boo
@@ -291,6 +291,8 @@ class PatternExpander:
 		patternLen = len(pattern.Items)
 		condition = [| $(patternLen) == len($matchValue) |]
 
+		if patternLen == 0: return condition
+
 		if IsCatchAllPattern(last = pattern.Items[patternLen-1]):
 			pattern.Items.Remove(last)
 			condition = [| $(patternLen) <= len($matchValue)+1 |]

--- a/tests/Boo.Lang.PatternMatching.Tests/MatchMacroTest.boo
+++ b/tests/Boo.Lang.PatternMatching.Tests/MatchMacroTest.boo
@@ -22,7 +22,13 @@ class MatchMacroTest:
 		match container:
 			case Container of Collection(value.Items: (item,)):
 				return item
-	
+
+	[Test]
+	def TestEmptyArrayMatch():
+		a = Collection(Items: [])
+		match a:
+			case Collection(Items: (,))	
+
 	[Test]
 	def DoubleMatch():
 		Assert.AreEqual("int int", doubleMatch(1, 2))


### PR DESCRIPTION
In pattern matching I tried to check if my array is empty but pattern matching returned compile time error message. So I created this fix. 
