### PR TITLE
Fix for generic class reference

### DIFF
--- a/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
+++ b/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
@@ -962,11 +962,6 @@ namespace Boo.Lang.Compiler
 			return Instantiate("BCE0176", node, typeName, expectedType, actualType);
 		}
 
-		public static CompilerError GenericParametersRequired(Node node, string typeName, int paramCount)
-		{
-			return Instantiate("BCE0177", node, typeName, paramCount);
-		}	
-
 		public static CompilerError Instantiate(string code, Exception error, params object[] args)
 		{
 			return new CompilerError(code, error, args);

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/NameResolutionService.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/NameResolutionService.cs
@@ -368,7 +368,8 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 				if (entity == null)
 				{
 					//Generic parameters are missing because there is no candidates after filtering out generic types
-					node.Entity = GenericParametersRequired(node, firstCandidate.ToString(), (firstCandidate as IType).GenericInfo.GenericParameters.Count());
+					GenericArgumentsCountMismatch(node, firstCandidate as IType);
+					node.Entity = TypeSystemServices.ErrorEntity;
 					return;
 				}
 			}
@@ -387,6 +388,7 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 				if (gtdr.GenericPlaceholders != type.GenericInfo.GenericParameters.Length)
 				{
 					GenericArgumentsCountMismatch(gtdr, type);
+					node.Entity = TypeSystemServices.ErrorEntity;
 					return;
 				}
 			}
@@ -475,13 +477,6 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 			return TypeSystemServices.ErrorEntity;
 		}
 
-		private IEntity GenericParametersRequired(SimpleTypeReference node, string fullName, int paramCount)
-		{			
-			CompilerErrors().Add(CompilerErrorFactory.GenericParametersRequired(node, fullName, paramCount));
-			return TypeSystemServices.ErrorEntity;
-		}
-		
-		
 		private CompilerErrorCollection CompilerErrors()
 		{
             return My<CompilerErrorCollection>.Instance;

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -179,7 +179,6 @@ namespace Boo.Lang.Resources
 		public const string BCE0174 = "'{0}' is not an interface. Only interface members can be explicitly implemented.";
 		public const string BCE0175 = "Nested type '{0}' cannot extend enclosing type '{1}'.";
 		public const string BCE0176 = "Incompatible partial definition for type '{0}', expecting '{1}' but got '{2}'.";
-		public const string BCE0177 = "Using the generic type '{0}' requires {1} type arguments.";
 		public const string BCW0000 = "WARNING: {0}";
 		public const string BCW0001 = "WARNING: Type '{0}' does not provide an implementation for '{1}' and will be marked abstract.";
 		public const string BCW0002 = "WARNING: Statement modifiers have no effect in labels.";

--- a/tests/testcases/net2/errors/BCE0139-5.boo
+++ b/tests/testcases/net2/errors/BCE0139-5.boo
@@ -1,6 +1,6 @@
 """
-BCE0139-5.boo(14,13): BCE0177: Using the generic type 'Container[of T, U]' requires 2 type arguments.
-BCE0139-5.boo(15,26): BCE0177: Using the generic type 'System.Collections.Generic.List[of T]' requires 1 type arguments.
+BCE0139-5.boo(14,13): BCE0139: 'Container[of T, U]' requires '2' arguments.
+BCE0139-5.boo(15,26): BCE0139: 'System.Collections.Generic.List[of T]' requires '1' arguments.
 BCE0139-5.boo(15,13): BCE0139: 'Container[of T, U]' requires '2' arguments.
 """
 import System.Collections.Generic


### PR DESCRIPTION
Currently references to generic classes are not checked for presence of generic arguments. For example the following code will compile and return runtime exception during execution"System.BadImageFormatException: An attempt was made to load a program with an incorrect format":

class Container[of T]:
    public value as T

x = Container of string()

print x isa Container

This is fix for case when generic arguments are not specified for generic class reference.
