### PR TITLE
Fixing incorrect warning BCW0007 in conditional expression.

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/PreErrorChecking.cs
+++ b/src/Boo.Lang.Compiler/Steps/PreErrorChecking.cs
@@ -136,13 +136,13 @@ namespace Boo.Lang.Compiler.Steps
 				Warnings.Add(CompilerWarningFactory.EqualsInsteadOfAssign(node));
 			}
 		}
-		
-		bool IsTopLevelOfConditional(Node child)
+
+		static bool IsTopLevelOfConditional(Node child)
 		{
-			Node parent = child.ParentNode;
+			var parent = child.ParentNode;
 			return (parent.NodeType == NodeType.IfStatement
 				|| parent.NodeType == NodeType.UnlessStatement
-				|| parent.NodeType == NodeType.ConditionalExpression
+				|| (parent.NodeType == NodeType.ConditionalExpression && ((ConditionalExpression) parent).Condition == child)
 				|| parent.NodeType == NodeType.StatementModifier
 				|| parent.NodeType == NodeType.ReturnStatement
 				|| parent.NodeType == NodeType.YieldStatement);

--- a/tests/testcases/warnings/BCW0007-1.boo
+++ b/tests/testcases/warnings/BCW0007-1.boo
@@ -6,3 +6,8 @@ b = true
 if a=b:
 	print "ok"
 
+x = System.Console.ReadLine()
+o = (1 if len(x) > 2 else m = 3) #No warning here
+print o, m
+
+


### PR DESCRIPTION
Conditional expression generates "BCW0007 WARNING: Assignment inside a conditional" if there is assignment in the true or false block. This is fixing it.
