### PR TITLE
Make CompilerParameters.ForName virtual

### DIFF
--- a/src/Boo.Lang.Compiler/CompilerParameters.cs
+++ b/src/Boo.Lang.Compiler/CompilerParameters.cs
@@ -205,7 +205,7 @@ namespace Boo.Lang.Compiler
 			return _compilerReferences.Provider.ForAssembly(assembly);
 		}
 
-		private Assembly ForName(string assembly, bool throwOnError)
+		protected virtual Assembly ForName(string assembly, bool throwOnError)
 		{
 			Assembly a = null;
 			try


### PR DESCRIPTION
 to allow descendant classes to provide their own means to load an assembly
