### PR TITLE
Annotate string quotes and new backtick quoted string

### DIFF
--- a/src/Boo.Lang.Parser/boo.g
+++ b/src/Boo.Lang.Parser/boo.g
@@ -3080,6 +3080,11 @@ string_literal returns [Expression e]
 	{
 		e = new StringLiteralExpression(ToLexicalInfo(tqs), tqs.getText());
 		e.Annotate("quote", "\"\"\"");
+	} |
+	bqs:BACKTICK_QUOTED_STRING
+	{
+		e = new StringLiteralExpression(ToLexicalInfo(bqs), bqs.getText());
+		e.Annotate("quote", "`");
 	}
 	;
 	
@@ -3604,6 +3609,15 @@ SINGLE_QUOTED_STRING :
 		~('\'' | '\\' | '\r' | '\n')
 	)*
 	'\''!
+	;
+
+BACKTICK_QUOTED_STRING :
+	'`'!
+	(
+		~('`' | '\r' | '\n') |
+		NEWLINE
+	)*
+	'`'!
 	;
 
 SL_COMMENT:


### PR DESCRIPTION
Sometimes it's useful to know from a macro or compiler step what kind of quotes were used for a string literal, allowing for example to automatically convert to char those strings with a length of 1 enclosed in single quotes. It's also pretty common for scripting languages to use the backtick "`" to quote literals to be executed verbatim. 

This pull request annotates string literals so that the exact quote character used is not lost when parsing and introduces a new string literal quoted by backticks which doesn't perform any escaping on the contents, ideal to define verbatim text with it.

```
exec `ls /path/to/dir | grep "foo" | wc -l`

eval `
    for i in range(10):
      print "Iteration $i" 
`
```
