### PR TITLE
Explicit cast to IDictionary to retrieve the correct enumerator

### DIFF
--- a/src/Boo.Lang/Hash.cs
+++ b/src/Boo.Lang/Hash.cs
@@ -170,7 +170,7 @@ namespace Boo.Lang
 
 		IDictionaryEnumerator IDictionary.GetEnumerator()
 		{
-			return _dictionary.GetEnumerator();
+			return ((IDictionary)_dictionary).GetEnumerator();
 		}
 
 		public void Remove(object key)


### PR DESCRIPTION
The generic Dictionary<TKey,TValue> implementation also implements
IDictionary. Under the covers it uses explicit interface implementations
to return a different IDictionaryEnumerator for GetEnumerator()
depending on how it's accessed. The Boo.Lang.Hash class uses a generic
dictionary internally for its data structure, and has an excplicit
interface implementation for IDictionary.GetEnumerator(), but doesn't
subsequently cast the private dictionary to IDictionary as well,
resulting in the incorrect IDictionaryEnumerator being returned.

The result is any callers doing something like:
foreach (DictionaryEntry entry in myBooHashVariable)
{ }
will throw an InvalidCastException, as the enumerator for
Dictionary<TKey,TResult> returns a KeyValuePair<TKey,TValue> and not a
DictionaryEntry.

Simply "continuing" the excplicit cast to IDictionary returns the
correct enumerator.

(debugging also courtesy of @craigdneo)
