### PR TITLE
Use runtime dispatching for argument exploding

### DIFF
--- a/src/Boo.Lang.Compiler/Pipelines/Compile.cs
+++ b/src/Boo.Lang.Compiler/Pipelines/Compile.cs
@@ -52,6 +52,8 @@ namespace Boo.Lang.Compiler.Pipelines
 			Add(new DetectNotImplementedFeatureUsage());
 			Add(new CheckAttributesUsage());
 
+			Add(new ExpandVarArgsMethodInvocations());
+			
 			Add(new ExpandDuckTypedExpressions());
 
 			Add(new ExpandComplexSlicingExpressions());
@@ -67,7 +69,6 @@ namespace Boo.Lang.Compiler.Pipelines
 			Add(new ProcessClosures());
 			Add(new ProcessGenerators());
 
-			Add(new ExpandVarArgsMethodInvocations());
 			
 			Add(new InjectCallableConversions());
 			Add(new ImplementICallableOnCallableDefinitions());

--- a/src/Boo.Lang.Compiler/Steps/ExpandVarArgsMethodInvocations.cs
+++ b/src/Boo.Lang.Compiler/Steps/ExpandVarArgsMethodInvocations.cs
@@ -73,7 +73,7 @@ namespace Boo.Lang.Compiler.Steps
 				node.Target = CodeBuilder.CreateMemberReference(
 					NameResolutionService.ResolveMethod(rt_type, "Invoke")
 				);
-				
+
 				node.Arguments.Clear();
 				node.Arguments.Add(target.Target);
 				node.Arguments.Add(CodeBuilder.CreateStringLiteral(target.Name));
@@ -86,9 +86,6 @@ namespace Boo.Lang.Compiler.Steps
 						((UnaryExpression)explode).Operand
 					)
 				);
-
-				AstUtil.DebugNode(node);
-				return;
 			}
 		}
 

--- a/src/Boo.Lang.Compiler/Steps/ExpandVarArgsMethodInvocations.cs
+++ b/src/Boo.Lang.Compiler/Steps/ExpandVarArgsMethodInvocations.cs
@@ -32,8 +32,7 @@ using Boo.Lang.Compiler.TypeSystem;
 
 namespace Boo.Lang.Compiler.Steps
 {
-	// AbstractFastVisitorCompilerStep
-	public class ExpandVarArgsMethodInvocations : AbstractTransformerCompilerStep
+	public class ExpandVarArgsMethodInvocations : AbstractFastVisitorCompilerStep
 	{
 		override public void Run()
 		{

--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodiesWithDuckTyping.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodiesWithDuckTyping.cs
@@ -29,6 +29,8 @@
 using Boo.Lang.Compiler.Ast;
 using Boo.Lang.Compiler.TypeSystem;
 
+using System;
+
 namespace Boo.Lang.Compiler.Steps
 {
 	public class ProcessMethodBodiesWithDuckTyping : ProcessMethodBodies
@@ -40,6 +42,22 @@ namespace Boo.Lang.Compiler.Steps
 		
 		override protected IEntity CantResolveAmbiguousMethodInvocation(MethodInvocationExpression node, IEntity[] entities)
 		{
+			// Any invocation with an explode expression is allowed
+			if (AstUtil.EndsWithExplodeExpression(node.Arguments) && entities.Length > 0) {
+				AstUtil.DebugNode(node);
+				Console.WriteLine("Entities: {0}", entities);
+				//NormalizeMethodInvocationTarget(node);
+				if (node.Target.NodeType == NodeType.ReferenceExpression) {
+					node.Target = MemberReferenceFromReference(
+						(ReferenceExpression)node.Target,
+						entities[0] as IMember
+					);
+				}
+				BindQuack(node.Target);
+				BindDuck(node);
+				return null;
+			}
+
 			if (!Ducky || CallableResolutionService.ValidCandidates.Count == 0)
 			{				
 				return base.CantResolveAmbiguousMethodInvocation(node, entities);

--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodiesWithDuckTyping.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodiesWithDuckTyping.cs
@@ -44,9 +44,6 @@ namespace Boo.Lang.Compiler.Steps
 		{
 			// Any invocation with an explode expression is allowed
 			if (AstUtil.EndsWithExplodeExpression(node.Arguments) && entities.Length > 0) {
-				AstUtil.DebugNode(node);
-				Console.WriteLine("Entities: {0}", entities);
-				//NormalizeMethodInvocationTarget(node);
 				if (node.Target.NodeType == NodeType.ReferenceExpression) {
 					node.Target = MemberReferenceFromReference(
 						(ReferenceExpression)node.Target,

--- a/src/Boo.Lang.Compiler/Steps/ReifyTypes.cs
+++ b/src/Boo.Lang.Compiler/Steps/ReifyTypes.cs
@@ -113,7 +113,7 @@ namespace Boo.Lang.Compiler.Steps
 
 		private static bool IsVarArgsInvocation(MethodInvocationExpression node, IEntityWithParameters entityWithParameters)
 		{
-			return entityWithParameters.AcceptVarArgs && !AstUtil.InvocationEndsWithExplodeExpression(node);
+			return entityWithParameters.AcceptVarArgs; 
 		}
 
 		private void TryToReify(Expression candidate, IType expectedType)

--- a/src/Boo.Lang.Compiler/Steps/StricterErrorChecking.cs
+++ b/src/Boo.Lang.Compiler/Steps/StricterErrorChecking.cs
@@ -186,10 +186,10 @@ namespace Boo.Lang.Compiler.Steps
 			}
 		}
 
-        public override void LeaveGeneratorExpression(GeneratorExpression node)
-        {
-            CheckExpressionType(node.Expression);
-        }
+		public override void LeaveGeneratorExpression(GeneratorExpression node)
+		{
+			CheckExpressionType(node.Expression);
+		}
 		
 		override public void LeaveBinaryExpression(BinaryExpression node)
 		{	
@@ -207,7 +207,7 @@ namespace Boo.Lang.Compiler.Steps
 
 			//check that the assignment or comparison is meaningful
 			if (BinaryOperatorType.Assign == node.Operator
-			    || AstUtil.GetBinaryOperatorKind(node) == BinaryOperatorKind.Comparison)
+				|| AstUtil.GetBinaryOperatorKind(node) == BinaryOperatorKind.Comparison)
 			{
 				if (AreSameExpressions(node.Left, node.Right))
 				{
@@ -218,7 +218,7 @@ namespace Boo.Lang.Compiler.Steps
 					);
 				}
 				else if (BinaryOperatorType.Assign != node.Operator
-				         && AreConstantExpressions(node.Left, node.Right))
+						 && AreConstantExpressions(node.Left, node.Right))
 				{
 					WarnAboutConstantExpression(node);
 				}
@@ -264,7 +264,7 @@ namespace Boo.Lang.Compiler.Steps
 		{	
 			if (!IsLastArgumentOfVarArgInvocation(node))
 			{
-                Error(CompilerErrorFactory.ExplodeExpressionMustMatchVarArgCall(node));
+				Error(CompilerErrorFactory.ExplodeExpressionMustMatchVarArgCall(node));
 			}
 		}
 
@@ -316,7 +316,7 @@ namespace Boo.Lang.Compiler.Steps
 			}
 
 			if ((e as LiteralExpression) != null
-			    && !e.ContainsAnnotation(ConstantFolding.FoldedExpression))
+				&& !e.ContainsAnnotation(ConstantFolding.FoldedExpression))
 				return true;
 
 			if (IsImplicitCallable(e))
@@ -555,11 +555,11 @@ namespace Boo.Lang.Compiler.Steps
 				return;
 
 			if (null == node.ReturnType
-			    || null == node.ReturnType.Entity
-			    || node.ReturnType.Entity == TypeSystemServices.VoidType
-			    || node.Body.IsEmpty
-			    || ((InternalMethod)node.Entity).IsGenerator
-			    || node.Name == "ExpandImpl") //ignore old-style macros
+				|| null == node.ReturnType.Entity
+				|| node.ReturnType.Entity == TypeSystemServices.VoidType
+				|| node.Body.IsEmpty
+				|| ((InternalMethod)node.Entity).IsGenerator
+				|| node.Name == "ExpandImpl") //ignore old-style macros
 				return;
 
 			if (!AstUtil.AllCodePathsReturnOrRaise(node.Body))
@@ -611,8 +611,8 @@ namespace Boo.Lang.Compiler.Steps
 		override public void LeaveExceptionHandler(ExceptionHandler node)
 		{
 			if (null != node.Declaration.Type.Entity
-			    && ((IType)node.Declaration.Type.Entity).FullName == "System.Exception"
-			    && !string.IsNullOrEmpty(node.Declaration.Name))
+				&& ((IType)node.Declaration.Type.Entity).FullName == "System.Exception"
+				&& !string.IsNullOrEmpty(node.Declaration.Name))
 			{
 				if (null != NameResolutionService.ResolveTypeName(new SimpleTypeReference(node.Declaration.Name)))
 					Warnings.Add(CompilerWarningFactory.AmbiguousExceptionName(node));
@@ -647,7 +647,7 @@ namespace Boo.Lang.Compiler.Steps
 			return false;
 		}
 
-	    static bool IsAddressOfBuiltin(Expression node)
+		static bool IsAddressOfBuiltin(Expression node)
 		{
 			return BuiltinFunction.AddressOf == node.Entity;
 		}

--- a/src/Boo.Lang.Compiler/Steps/StricterErrorChecking.cs
+++ b/src/Boo.Lang.Compiler/Steps/StricterErrorChecking.cs
@@ -264,7 +264,7 @@ namespace Boo.Lang.Compiler.Steps
 		{	
 			if (!IsLastArgumentOfVarArgInvocation(node))
 			{
-				Error(CompilerErrorFactory.ExplodeExpressionMustMatchVarArgCall(node));
+                Error(CompilerErrorFactory.ExplodeExpressionMustMatchVarArgCall(node));
 			}
 		}
 
@@ -349,12 +349,7 @@ namespace Boo.Lang.Compiler.Steps
 		{
 			MethodInvocationExpression parent = node.ParentNode as MethodInvocationExpression;
 			if (null == parent) return false;
-			if (parent.Arguments.Last != node) return false;
-			ICallableType type = parent.Target.ExpressionType as ICallableType;
-			if (null != type) return type.GetSignature().AcceptVarArgs;
-			
-			IMethod method = parent.Target.Entity as IMethod;
-			return null != method && method.AcceptVarArgs;
+			return parent.Arguments.Last == node;
 		}
 
 		static bool IsTypeReference(Expression node)


### PR DESCRIPTION
Currently Boo does only allow the following use of the explode arguments operator:

    def bar(a, *args)  
    # bar(1, *(2, 3)) 

The following changes allow to have a more powerful exploding operator which works like the one in Python. The drawback is that it uses the runtime to actually dispatch the call, with a bit more work the original use case supported by Boo could bypass the runtime dependency but it's not worth the effort IMHO.

    def foo(a, b, c)
    # foo(1, *(2, 3))
    def bar(a, *args)
    # bar(1, *(2, 3))
    # bar(*(1, 2, 3))
    # bar(1, 2, *(3,))
    # bar(1, 2, 3)

NOTE: No unit tests yet, I'll provide them if you think this could actually be merged. :octocat: 