### PR TITLE
Integrate travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Travis-CI Build for BooJs
+# Travis-CI Build for Boo
 # see travis-ci.org for details
 
 language: c


### PR DESCRIPTION
Travis-ci does not support .Net/Mono projects natively so the build is based on a C environment (linux), where it will install via `apt-get` a version of Mono and its dev tools.

The current build file has been tested to be able to successfully launch a `nant rebuild` on the Travis machines. I haven't been able to make the tests compilation work, I guess the nant build file would have to be modified to make it compatible with that linux environment.
