### PR TITLE
Make GetUniqueName() virtual so it's possible to inject a customized version

### DIFF
--- a/src/Boo.Lang.Compiler/Services/UniqueNameProvider.cs
+++ b/src/Boo.Lang.Compiler/Services/UniqueNameProvider.cs
@@ -29,27 +29,27 @@
 
 namespace Boo.Lang.Compiler.Services
 {
-    public class UniqueNameProvider
-    {
-        private int _localIndex;
+	public class UniqueNameProvider
+	{
+		private int _localIndex;
 
-        ///<summary>Generates a name that will be unique within the CompilerContext.</summary>
-        ///<param name="components">Zero or more string(s) that will compose the generated name.</param>
-        ///<returns>Returns the generated unique name.</returns>
-        public virtual string GetUniqueName(params string[] components)
-        {
-            var suffix = string.Concat("$", (++_localIndex).ToString());
-            if (components == null || components.Length == 0)
-                return suffix;
+		///<summary>Generates a name that will be unique within the CompilerContext.</summary>
+		///<param name="components">Zero or more string(s) that will compose the generated name.</param>
+		///<returns>Returns the generated unique name.</returns>
+		public virtual string GetUniqueName(params string[] components)
+		{
+			var suffix = string.Concat("$", (++_localIndex).ToString());
+			if (components == null || components.Length == 0)
+				return suffix;
 
-            var sb = new System.Text.StringBuilder();
-            foreach (var component in components)
-            {
-                sb.Append("$");
-                sb.Append(component);
-            }
-            sb.Append(suffix);
-            return sb.ToString();
-        }
-    }
+			var sb = new System.Text.StringBuilder();
+			foreach (var component in components)
+			{
+				sb.Append("$");
+				sb.Append(component);
+			}
+			sb.Append(suffix);
+			return sb.ToString();
+		}
+	}
 }


### PR DESCRIPTION
In order to provide my own logic for the unique names generator I inject my own implementation of `UniqueNameProvider`. However the original method is not flagged as virtual so my custom implementation is never actually reached.
