### PR TITLE
Fix pedump running under Mono

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/PEVerify.cs
+++ b/src/Boo.Lang.Compiler/Steps/PEVerify.cs
@@ -29,6 +29,8 @@
 namespace Boo.Lang.Compiler.Steps
 {
 	using System.Diagnostics;
+	using System.Text;
+	using System.IO;
 	using Boo.Lang.Compiler;
 
 	public class PEVerify : AbstractCompilerStep
@@ -58,7 +60,7 @@ namespace Boo.Lang.Compiler.Steps
 			
 			try
 			{
-				var p = Builtins.shellp(command, arguments);
+				var p = StartProcess(Path.GetDirectoryName(Parameters.OutputAssembly), command, arguments);
 				p.WaitForExit();
 				if (0 != p.ExitCode)
 					Errors.Add(new CompilerError(Ast.LexicalInfo.Empty, p.StandardOutput.ReadToEnd()));
@@ -70,5 +72,30 @@ namespace Boo.Lang.Compiler.Steps
 			}
 #endif
 		}
+		
+#if !NO_SYSTEM_PROCESS
+		public Process StartProcess(string workingdir, string filename, string arguments)
+		{
+			var p = new Process();
+			p.StartInfo.Arguments = arguments;
+			p.StartInfo.CreateNoWindow = true;
+			p.StartInfo.UseShellExecute = false;
+			p.StartInfo.RedirectStandardOutput = true;
+			p.StartInfo.RedirectStandardInput = true;
+			p.StartInfo.RedirectStandardError = true;
+			p.StartInfo.FileName = filename;
+
+			// Mono's pedump won't find the dependent assemblies if the output 
+			// directory is not in the path. It can also give problems with the 
+			// encoding if it's not forced to one.
+			if (System.Type.GetType("Mono.Runtime") != null) {
+				p.StartInfo.EnvironmentVariables["MONO_PATH"] = workingdir;
+				p.StartInfo.StandardOutputEncoding = Encoding.UTF8;
+				p.StartInfo.StandardErrorEncoding = Encoding.UTF8;
+			}
+			p.Start();
+			return p;
+		}
+#endif
 	}
 }

--- a/src/Boo.Lang/Builtins.cs
+++ b/src/Boo.Lang/Builtins.cs
@@ -231,8 +231,6 @@ namespace Boo.Lang
 			p.StartInfo.RedirectStandardOutput = true;
 			p.StartInfo.RedirectStandardInput = true;
 			p.StartInfo.RedirectStandardError = true;
-			p.StartInfo.StandardOutputEncoding = Encoding.UTF8;
-			p.StartInfo.StandardErrorEncoding = Encoding.UTF8;
 			p.StartInfo.FileName = filename;
 			p.Start();
 			return p;


### PR DESCRIPTION
I tracked down the issue of the corrupted error messages when running the unit tests. The problem was in the builtin function `shellp`, which wasn't forcing a specific encoding on the pipes.

The PEVerify step uses that function to run `pedump` (on linux/mac), which is failing for quite some test cases, but the error wasn't readable (ie: _楍獳湩⁧敭桴摯⸠..._). One of the errors is for example:

```
Missing method .ctor in assembly /private/var/folders/hl/nh1bjvfs5gvgplmz5t391fc80000gn/T/msbuild/testcase.exe, type Boo.Lang.MetaAttribute
Error: Invalid CustomAttribute content row 2 Value field 0x0000015c
Error: CustomAttribute: Invalid constructor
Error count: 2
```

Although there are many more failing with:

```
Could not load class with token 2000003
* Assertion at class.c:5594, condition `!mono_loader_get_last_error ()' not met
```

Anyhow, I guess that enforcing a given encoding for the output pipes in the `shellp` does little harm and in return solves the issue with the junk errors.
