### PR TITLE
Allow spaces and comments after continuation

### DIFF
--- a/src/Boo.Lang.Parser/boo.g
+++ b/src/Boo.Lang.Parser/boo.g
@@ -3436,10 +3436,16 @@ protected ID_SUFFIX:
 ;
 
 LINE_CONTINUATION:
-	'\\' (' '|'\t')* (SL_COMMENT)? NEWLINE
+	'\\' 
+	(
+		NEWLINE
+		| (' ' | '\t')+
+		| SL_COMMENT
+		| ML_COMMENT
+	)+
 	{ $setType(Token.SKIP); }
 	;
-	
+
 INT : 
   	("0x"(HEXDIGIT)+)(('l' | 'L') { $setType(LONG); })? |
   	DIGIT_GROUP

--- a/src/Boo.Lang.Parser/wsaboo.g
+++ b/src/Boo.Lang.Parser/wsaboo.g
@@ -3167,9 +3167,15 @@ protected ID_SUFFIX:
 ;
 
 LINE_CONTINUATION:
-	'\\' (' '|'\t')* (SL_COMMENT)? NEWLINE
+	'\\' 
+	(
+		NEWLINE
+		| (' ' | '\t')+
+		| SL_COMMENT
+		| ML_COMMENT
+	)+
 	{ $setType(Token.SKIP); }
-	;
+	;	
 	
 INT : 
   	("0x"(HEXDIGIT)+)(('l' | 'L') { $setType(LONG); })? |


### PR DESCRIPTION
Continuations are used to break up complex logic and I find it frustrating being unable to use comments in them. This change to the grammar serves two purposes:
1. it removes the shell scripting legacy of not being able to have trailing spaces
2. allows comments between the continuation and the next expression

``` boo
    if Path.Exists(fpath) and \
       check_header(fpath) and \   # comment
       # not_working(fpath) and \
       is_valid():
        return True 
```
