### PR TITLE
Move entity mapping for void, object and duck to a virtual method

### DIFF
--- a/src/Boo.Lang.Compiler/TypeSystem/Reflection/ReflectionTypeSystemProvider.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Reflection/ReflectionTypeSystemProvider.cs
@@ -41,7 +41,11 @@ namespace Boo.Lang.Compiler.TypeSystem.Reflection
 		public ReflectionTypeSystemProvider()
 		{
 			_referenceCache = new MemoizedFunction<Assembly, AssemblyReference>(AssemblyEqualityComparer.Default, CreateReference);
+			Initialize();
+		}
 
+		virtual protected void Initialize()
+		{
 			MapTo(typeof(object), new ObjectTypeImpl(this));
 			MapTo(typeof(Builtins.duck), new ObjectTypeImpl(this));
 			MapTo(typeof(void), new VoidTypeImpl(this));


### PR DESCRIPTION
In BooJs I want to map `System.Object` to a custom type. Since `ReflectionTypeSystemProvider` maps `object`, `duck` and `void` in its constructor is not possible to apply a custom mapping for them in descendant implementations because the `MemoizedFunction` cache complain that the key is already defined.

This patch moves the mapping to a virtual `Initialize` method that can be overridden in order to configure custom mappings for any type.
