### PR TITLE
Annotate aliased selective imports

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/ResolveImports.cs
+++ b/src/Boo.Lang.Compiler/Steps/ResolveImports.cs
@@ -152,6 +152,7 @@ namespace Boo.Lang.Compiler.Steps
 					name = (tce.Target as ReferenceExpression).Name;
 					aliases[alias] = name;
 					// Remove the trycast expression, otherwise it gets processed in later steps
+					tce.Target.Annotate("alias", alias);
 					importedNames.Replace(nameExpression, tce.Target);
 				}
 


### PR DESCRIPTION
Annotates the reference expression in selective imports to make it possible to reconstruct them from the AST.
