### PR TITLE
Support value comparison for defines

### DIFF
--- a/src/Boo.Lang.Extensions/Macros/IfdefMacro.boo
+++ b/src/Boo.Lang.Extensions/Macros/IfdefMacro.boo
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // Copyright (c) 2009 Rodrigo B. de Oliveira (rbo@acm.org)
 // All rights reserved.
 // 
@@ -59,6 +59,25 @@ class IfdefMacro(AbstractAstMacro):
 		return Parameters.Defines.ContainsKey(condition.Name)
 
 	private def EvaluateBinary(condition as BinaryExpression):
+		if condition.Operator in (BinaryOperatorType.Equality, BinaryOperatorType.Inequality):
+			lft = condition.Left.ToString()
+
+			if not Parameters.Defines.ContainsKey(lft):
+				return false
+
+			rgt as string
+			if condition.Right isa ReferenceExpression:
+				rgt = (condition.Right as ReferenceExpression).Name
+			elif condition.Right isa StringLiteralExpression:
+				rgt = (condition.Right as StringLiteralExpression).Value
+			else:
+				rgt = condition.Right.ToString()
+				
+			if condition.Operator == BinaryOperatorType.Equality:
+				return Parameters.Defines[lft] == rgt
+			else:
+				return Parameters.Defines[lft] != rgt
+
 		if condition.Operator == BinaryOperatorType.Or:
 			return Evaluate(condition.Left) or Evaluate(condition.Right)
 		if condition.Operator == BinaryOperatorType.And:

--- a/tests/testcases/macros/ifdef-1.boo
+++ b/tests/testcases/macros/ifdef-1.boo
@@ -15,6 +15,12 @@ FOO or BAR
 DEFINES: BAZ
 not FOO
 not BAR
+DEFINES: FOO=foo, QUX=qux
+FOO
+FOO or BAR
+not BAR
+FOO == 'foo'
+(QUX == qux) or (QUX == 10)
 """
 import Boo.Lang.Compiler
 import Boo.Lang.Compiler.Ast
@@ -24,7 +30,12 @@ def compileWithDefines(module as Module, *defines as (string)):
 	compiler.Parameters.Pipeline = Pipelines.CompileToMemory()
 	compiler.Parameters.References.Add(System.Reflection.Assembly.GetExecutingAssembly())
 	for define in defines:
-		compiler.Parameters.Defines.Add(define, null)
+		pair = define.Split("=".ToCharArray(), 2)
+		if len(pair) == 2:
+			compiler.Parameters.Defines.Add(pair[0], pair[1])
+		else:
+			compiler.Parameters.Defines.Add(pair[0], null)
+
 	result = compiler.Run(CompileUnit(module.CloneNode()))
 	assert len(result.Errors) == 0, result.Errors.ToString(true)
 	return result.GeneratedAssembly
@@ -48,7 +59,8 @@ module = [|
 	printIfdef FOO or BAR
 	printIfdef not FOO
 	printIfdef not BAR
-	
+	printIfdef FOO == 'foo'
+	printIfdef QUX == qux or QUX == 10
 |]
 
 
@@ -56,4 +68,4 @@ runWithDefines module, "FOO"
 runWithDefines module, "BAR"
 runWithDefines module, "FOO", "BAR"
 runWithDefines module, "BAZ"
-	
+runWithDefines module, "FOO=foo", "QUX=qux"


### PR DESCRIPTION
Enables equality comparison for the `ifdef` macro

```
ifdef FOO == foo or BAR == 'has spaces':
  print 'equality comparison'
```
