### PR TITLE
Update travis build to use official Mono

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 # Travis-CI Build for Boo
 # see travis-ci.org for details
 
-language: objective-c
+language: csharp
+
+# Choose a compatible Mono version
+mono:
+  - 3.12.0
 
 env:
   global:
@@ -11,16 +15,8 @@ env:
     - NUNIT_VERSION="2.6.3"
     - NANT_COMMIT="3074f62bdce616058f19c1d6e27bf1bdb1953849"
     - PKG_CONFIG_PATH=/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig/
-  matrix:
-    - MONO_VER="3.2.3"
 
 install:
-  # Obtain mono from a fast mirror (over 150Mb download)
-  # - wget "http://switch.dl.sourceforge.net/project/mono.mirror/MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.pkg"
-  # - wget "http://optimate.dl.sourceforge.net/project/mono.mirror/MonoFramework-MDK-$MONO_VER.macos10.xamarin.x86.pkg"
-  - wget "http://hivelocity.dl.sourceforge.net/project/mono.mirror/MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.pkg"
-  # Install mono
-  - sudo installer -pkg "MonoFramework-MDK-${MONO_VER}.macos10.xamarin.x86.pkg" -target /
   # Fetch a version of NAnt compatible with Mono 3
   - wget -nv --no-check-certificate "https://github.com/nant/nant/archive/${NANT_COMMIT}.zip"
   - unzip -qq "${NANT_COMMIT}"


### PR DESCRIPTION
Travis CI introduced recently the possibility to build mono projects in a semi official way: https://docs.travis-ci.com/user/languages/csharp/

The changes here make use of that functionality instead of manually downloading and installing Mono on an OSX machine. Now the build will be performed on Linux and we can even add multiple Mono versions to test.

NAnt and NUnit are still installed manually.