### PR TITLE
Fix building on non windows with mono

### DIFF
--- a/default.build
+++ b/default.build
@@ -396,7 +396,6 @@
 	
 	<target name="Boo.Microsoft.Build.Tasks" depends="core">
 		<property name="backup.currentframework" value="${nant.settings.currentframework}" />
-		<property name="nant.settings.currentframework" value="mono-2.0" unless="${platform::is-windows()}" />
 		<booc target="library"	
 			output="${build.dir}/Boo.Microsoft.Build.Tasks.dll"
 			failonerror="true" 

--- a/default.build
+++ b/default.build
@@ -396,6 +396,7 @@
 	
 	<target name="Boo.Microsoft.Build.Tasks" depends="core">
 		<property name="backup.currentframework" value="${nant.settings.currentframework}" />
+		<property name="nant.settings.currentframework" value="mono-4.0" unless="${platform::is-windows()}" />
 		<booc target="library"	
 			output="${build.dir}/Boo.Microsoft.Build.Tasks.dll"
 			failonerror="true" 


### PR DESCRIPTION
Setting the version to mono-2.0 for microsoft build tasks breaks the build. Because it tries to override something which I guess wasn't in 2.0