### PR TITLE
Mark tests failing under Mono 4.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
   - wget -nv --no-check-certificate "https://github.com/nant/nant/archive/${NANT_COMMIT}.zip"
   - unzip -qq "${NANT_COMMIT}"
   - cd "nant-${NANT_COMMIT}"
-  - make setup bootstrap/NAnt.exe bootstrap/NAnt.Core.dll bootstrap/NAnt.DotNetTasks.dll
+  # On Mono 4.x the gmcs command is no longer present
+  - make MCS=mcs setup bootstrap/NAnt.exe bootstrap/NAnt.Core.dll bootstrap/NAnt.DotNetTasks.dll
   - cp -r bootstrap ../nant
   - cd -
   # Fetch a recent version of NUnit

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: csharp
 
 # Choose a compatible Mono version
 mono:
-  - 3.12.0
+  - 4.2.1
 
 env:
   global:
@@ -40,7 +40,7 @@ script:
  # Replace the nunit framework dll with the downloaded version
  - cp -f "../NUnit-${NUNIT_VERSION}/bin/framework/nunit.framework.dll" build/.
  - cd build
- - MONO_PATH=. PEVERIFY=false mono --runtime=v4.0 --gc=boehm "../../NUnit-${NUNIT_VERSION}/bin/nunit-console.exe" -framework=4.0 -stoponerror -nologo -timeout=10000 -noresult -output=stdout.txt -domain=none -exclude=FailsOnMono *.Tests.dll
+ - MONO_PATH=. PEVERIFY=false mono --runtime=v4.0 --gc=boehm "../../NUnit-${NUNIT_VERSION}/bin/nunit-console.exe" -framework=4.0 -stoponerror -nologo -timeout=10000 -noresult -output=stdout.txt -domain=none -exclude=FailsOnMono,FailsOnMono4 *.Tests.dll
 
 after_success:
  # Generate a simple distribution file

--- a/default.build
+++ b/default.build
@@ -6,18 +6,18 @@
 
 	<!-- freeze AssemblyVersion to avoid backwards compatibility issues -->
 	<property name="boo.assembly.version" value="2.0.9.5" />
-	
+
 	<property name="debug" value="true" />
 	<property name="optimize" value="false" />
 	<property name="verbose" value="false" />
 	<property name="defines" value="" unless="${property::exists('defines')}" />
-	
+
 	<property name="mono" value="${'mono' == framework::get-family(framework::get-runtime-framework())}" />
 
 	<property name="java" value="java" />
 	<property name="antlr.jar" value="lib/antlr-2.7.5/antlr-2.7.5.jar" />
 	<property name="antlr.trace" value="False" />
-	
+
 	<property name="ngen.exe" value="${framework::get-framework-directory(framework::get-target-framework())}/ngen.exe" />
 	<property name="skip.ngen" value="True" />
 	<property name="skip.antlr" value="False" />
@@ -26,7 +26,7 @@
 	<property name="skip.errorpatterns" value="False" />
 
 	<property name="gsv.name" value="gtksourceview-1.0" />
-	
+
 	<property name="build.dir" value="build" dynamic="True"/>
 	<property name="distrobuild.dir" value="distrobuild"/>
 	<property name="docs.dir" value="docs" />
@@ -58,13 +58,13 @@
 	<property name="gendarme.set" value=""/>
 
 	<include buildfile="build.properties" if="${file::exists('build.properties')}" />
-	
+
 	<property name="boo.distro.name" value="boo-${boo.version}" />
-	
+
 	<property name="supported.runtimes.net-1.1" value="&lt;supportedRuntime version=&quot;v1.1.4322&quot;/&gt;
 &lt;supportedRuntime version=&quot;v2.0.50727&quot;/&gt;" />
-	
-	<property name="supported.runtimes.net-2.0" 
+
+	<property name="supported.runtimes.net-2.0"
 		value="&lt;supportedRuntime version=&quot;v2.0.50727&quot;/&gt;
 &lt;supportedRuntime version=&quot;v1.1.4322&quot;/&gt;" />
 
@@ -85,17 +85,17 @@
 		<property name="supported.runtimes" value="${supported.runtimes.net-2.0}" />
 		<property name="csc.4.define" value="" />
 	</if>
-			
-	<property name="csc.noconfig" value="false" />	
+
+	<property name="csc.noconfig" value="false" />
 	<property name="csc.define.custom" value="NO_CUSTOM_DEFINE" unless="${property::exists('csc.define.custom')}" />
 	<property name="csc.define" value="${csc.4.define}NET_2_0;TRACE;DEBUG;${csc.define.custom}" />
 
 	<property name="fixture" value="" dynamic="true" />
-	
+
 	<property name="nosign" value="false" />
-	
+
 	<property name="nant-csc-keyfile-bug" value="${version::get-minor(assemblyname::get-version(assembly::get-name(nant::get-assembly()))) &lt; 86}" />
-	
+
 	<target name="sign">
 		<property name="keyfile.path" value="src/boo.snk" overwrite="false" />
 	</target>
@@ -109,7 +109,7 @@
 		<call target="gendarme" if="${gendarme.dir != ''}" />
 		<call target="verify-assemblies" />
 	</target>
-	
+
 	<target name="verify-assemblies" if="${mono}">
 		<foreach item="File" property="filename">
 		<in>
@@ -134,12 +134,12 @@
 		<property name="optimize" value="true" />
 		<property name="csc.define" value="NET_2_0;${csc.define.custom}" />
 	</target>
-	
+
 	<target name="nostdlib">
 		<property name="csc.define" value="${csc.define};NO_SYSTEM_DLL" />
 		<property name="csc.noconfig" value="true" />
 	</target>
-	
+
 	<target name="test" depends="all">
 		<exec
 			basedir="${nant::get-base-directory()}"
@@ -151,7 +151,7 @@
 			<arg value="run" />
 		</exec>
 	</target>
-	
+
 	<target name="test-vs-bin">
 		<exec
 			basedir="${nant::get-base-directory()}"
@@ -162,7 +162,7 @@
 			<arg value="run-vs-bin" />
 		</exec>
 	</target>
-	
+
 	<target name="compile-tests" depends="all">
 		<exec
 			basedir="${nant::get-base-directory()}"
@@ -173,7 +173,7 @@
 			<arg value="compile" />
 		</exec>
 	</target>
-	
+
 	<target name="booish" depends="Boo.Lang.Interpreter">
 		<booc
 			target="exe"
@@ -181,7 +181,7 @@
 			verbose="${verbose}"
 			debug="${debug}"
 			define="${defines}">
-			
+
 			<sources basedir="src/booish">
 				<include name="*.boo" />
 			</sources>
@@ -195,7 +195,7 @@
 
 		<copy file="extras/template.config.in" tofile="${build.dir}/booish.exe.config">
 			<filterchain>
-				<replacestring from="@SUPPORTEDVERSIONS@" 
+				<replacestring from="@SUPPORTEDVERSIONS@"
 					to="${supported.runtimes}" />
 			</filterchain>
 		</copy>
@@ -218,26 +218,26 @@
 			verbose="${verbose}"
 			debug="${debug}"
 			define="${defines}">
-			
+
 			<references basedir="${build.dir}">
 				<include name="Boo.Lang.Parser.dll" />
 				<include name="Boo.Lang.Compiler.dll" />
 				<include name="Boo.Lang.Useful.dll" />
 			</references>
-			
+
 			<sources basedir="src/booi">
 				<include name="*.boo" />
 			</sources>
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
-		</booc>		
-		
+		</booc>
+
 		<copy file="extras/template.config.in" tofile="${build.dir}/booi.exe.config">
 			<filterchain>
-				<replacestring from="@SUPPORTEDVERSIONS@" 
+				<replacestring from="@SUPPORTEDVERSIONS@"
 					to="${supported.runtimes}" />
 			</filterchain>
 		</copy>
-		
+
 		<if test="${not(platform::is-windows())}">
 			<copy file="extras/booi.in" tofile="${build.dir}/booi" inputencoding="ASCII">
 				<filterchain>
@@ -249,28 +249,28 @@
 		</if>
 
 		<boo>
-		print("Hello from boo task!")		
+		print("Hello from boo task!")
 		print("Framework directory: ${Project.TargetFramework.FrameworkAssemblyDirectory}")
 		</boo>
 
 	</target>
-	
+
 	<target name="dump-properties" depends="core">
 		<boo>
 		for p as System.Collections.DictionaryEntry in Project.Properties:
-			print("${p.Key}: ${p.Value}")		
+			print("${p.Key}: ${p.Value}")
 		</boo>
 	</target>
-	
+
 	<target name="Boo.Lang.PatternMatching" depends="core">
-	
+
 		<booc target="library" output="${build.dir}/Boo.Lang.PatternMatching.dll">
 			<sources basedir="src/Boo.Lang.PatternMatching">
 				<include name="**/*.boo" />
 			</sources>
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</booc>
-		
+
 	</target>
 
 	<target name="Boo.Lang.Interpreter" depends="Boo.Lang.PatternMatching, core">
@@ -299,15 +299,15 @@
 				<include name="${build.dir}/Boo.NAnt.Tasks.dll" />
 			</targetfiles>
 		</uptodate>
-		
+
 		<if test="${debug}">
 			<property name="debugflag" value="-debug"/>
 		</if>
 		<if test="${not debug}">
 			<property name="debugflag" value="-debug-"/>
 		</if>
-		
-		<exec program="${build.dir}/booc.exe" useruntimeengine="true" unless="${Boo.NAnt.Tasks-is-uptodate}">		
+
+		<exec program="${build.dir}/booc.exe" useruntimeengine="true" unless="${Boo.NAnt.Tasks-is-uptodate}">
 			<arg value="-v" />
 			<arg value="-noconfig" />
 			<arg value="${debugflag}" />
@@ -318,14 +318,14 @@
 			<arg value="-srcdir:src/Boo.NAnt.Tasks" />
 			<arg line='"-lib:${nant::get-base-directory()}"' />
 		</exec>
-		
+
 		<loadtasks assembly="${build.dir}/Boo.NAnt.Tasks.dll" />
 	</target>
-	
+
 	<target name="booc" depends="corecs">
-		<csc target="exe" 
-				output="${build.dir}/booc.exe" 
-				debug="${debug}" 
+		<csc target="exe"
+				output="${build.dir}/booc.exe"
+				debug="${debug}"
 				optimize="${optimize}"
 				define="${csc.define}">
 			<sources basedir="src/booc">
@@ -349,30 +349,30 @@
 				</filterchain>
 			</copy>
 		</if>
-		
+
 		<copy todir="${build.dir}" file="src/booc/booc.rsp" />
-		
+
 		<copy file="extras/template.config.in" tofile="${build.dir}/booc.exe.config">
 			<filterchain>
-				<replacestring from="@SUPPORTEDVERSIONS@" 
+				<replacestring from="@SUPPORTEDVERSIONS@"
 					to="${supported.runtimes}" />
 			</filterchain>
 		</copy>
-		
+
 		<exec program='${ngen.exe}' if="${file::exists(ngen.exe)}" unless="${skip.ngen}">
 			<arg file='${build.dir}/Boo.Lang.dll' />
 			<arg file='${build.dir}/Boo.Lang.Compiler.dll' />
-			<arg file='${build.dir}/Boo.Lang.Extensions.dll' />			
+			<arg file='${build.dir}/Boo.Lang.Extensions.dll' />
 			<arg file='${build.dir}/Boo.Lang.Parser.dll' />
 			<arg file='${build.dir}/booc.exe' />
 		</exec>
 	</target>
-	
+
 	<target name="corecs" depends="Boo.Lang, Boo.Lang.Compiler, Boo.Lang.Parser">
 	</target>
-	
+
 	<target name="core" depends="corecs, Boo.Lang.Extensions, Boo.NAnt.Tasks" />
-	
+
 	<target name="update-bin" depends="all">
 		<mkdir dir="bin" />
 		<delete>
@@ -393,13 +393,11 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="Boo.Microsoft.Build.Tasks" depends="core">
-		<property name="backup.currentframework" value="${nant.settings.currentframework}" />
-		<property name="nant.settings.currentframework" value="mono-2.0" unless="${platform::is-windows()}" />
-		<booc target="library"	
+		<booc target="library"
 			output="${build.dir}/Boo.Microsoft.Build.Tasks.dll"
-			failonerror="true" 
+			failonerror="true"
 			verbose="${verbose}"
 			debug="${debug}"
 			define="${defines}">
@@ -413,14 +411,13 @@
 			</references>
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</booc>
-		<property name="nant.settings.currentframework" value="${backup.currentframework}" />
 		<copy todir="${build.dir}">
 			<fileset basedir="src/Boo.Microsoft.Build.Tasks">
 				<include name="Boo.Microsoft.Build.targets" />
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="Boo.Lang.Useful" depends="core">
 		<uptodate property="useful-grammars-uptodate">
 			<sourcefiles basedir="src/Boo.Lang.Useful">
@@ -441,7 +438,7 @@
 				<arg value="src/Boo.Lang.Useful/IO/PreProcessorExpressions.g" />
 			</exec>
 		</if>
-		
+
 		<booc target="library"
 			output="${build.dir}/Boo.Lang.Useful.dll"
 			verbose="${verbose}"
@@ -460,7 +457,7 @@
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</booc>
 	</target>
-	
+
 	<target name="Boo.Lang.CodeDom" depends="core">
 		<booc target="library"
 			output="${build.dir}/Boo.Lang.CodeDom.dll"
@@ -480,7 +477,7 @@
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</booc>
 	</target>
-	
+
 	<target name="Boo.Lang.Extensions" depends="corecs, Boo.NAnt.Tasks">
 		<booc target="library"
 			output="${build.dir}/Boo.Lang.Extensions.dll"
@@ -501,7 +498,7 @@
 			<arg line="-keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</booc>
 	</target>
-	
+
 
 	<target name="Boo.Lang.Compiler" depends="Boo.Lang, Boo.Lang.Ast">
 		<csc target="library"
@@ -509,11 +506,11 @@
 			debug="${debug}"
 			optimize="${optimize}"
 			define="${csc.define}">
-			
+
 			<sources basedir="src/Boo.Lang.Compiler">
 				<include name="**/*.cs" />
 			</sources>
-			
+
 			<references>
 				<include name="${build.dir}/Boo.Lang.dll" />
 				<!--include name="${build.dir}/Boo.Lang.Ast.dll" /-->
@@ -523,23 +520,23 @@
 	</target>
 
 	<target name="Boo.Lang.Ast" depends="Boo.Lang, generate-ast">
-		<!--csc 
+		<!--csc
 			target="library"
 			output="${build.dir}/Boo.Lang.Ast.dll"
 			debug="${debug}"
 			optimize="${optimize}"
 			define="${csc.define}">
-			
+
 			<sources basedir="src/Boo.Lang.Ast">
 				<include name="**/*.cs" />
 			</sources>
-			
+
 			<references>
 				<include name="${build.dir}/Boo.Lang.dll" />
 			</references>
 		</csc-->
 	</target>
-	
+
 	<target name="Boo.Lang" depends="init">
 		<csc
 			target="library"
@@ -558,7 +555,7 @@
 			<arg line="/keyfile:${keyfile.path}" unless="${keyfile.path == '' or nant-csc-keyfile-bug}" />
 		</csc>
 	</target>
-	
+
 	<target name="boo-pkgconfig">
 		<copy file="extras/boo.pc.in" tofile="${build.dir}/boo.pc" if="${not(platform::is-windows())}" inputencoding="ASCII">
 			<filterchain>
@@ -614,7 +611,7 @@
 			</exec>
 		</do>
 		</foreach>
-		
+
 		<copy todir="${fakeroot.bindir}">
 			<fileset basedir="${build.dir}">
 				<include name="booc"/>
@@ -629,7 +626,7 @@
 				<include name="boo.mime" />
 			</fileset>
 		</copy>
-		
+
 		<copy file="extras/boo.lang" todir="${fakeroot.gsv}/share/${gsv.name}/language-specs/" />
 		<copy file="${build.dir}/boo.pc" todir="${fakeroot.libdir}/pkgconfig/" />
 		<copy file="extras/boo-mime-info.xml" todir="${fakeroot.sharedmime}/share/mime/packages/" />
@@ -640,7 +637,7 @@
 
 		<!-- Copy over documentation -->
 		<mkdir dir="${fakeroot.boodocs}"/>
-		
+
 		<copy todir="${fakeroot.boodocs}">
 			<fileset basedir="${docs.dir}">
 				<include name="*.sxw" />
@@ -665,12 +662,12 @@
 	</target>
 
 	<target name="install-win32" depends="all">
-	
+
 		<fail unless="${property::exists('mono.prefix')}">
 		Please set the property 'mono.prefix' to point to the prefix of your
 		mono installation (example: c:\dotnet\mono-1.1.8).
 		</fail>
-		
+
 		<copy todir="${path::combine(mono.prefix, 'lib/boo')}">
 			<fileset basedir="${build.dir}">
 				<include name="*.exe"/>
@@ -699,7 +696,7 @@
 		</foreach>
 
 	</target>
-	
+
 	<target name="uninstall">
 		<call target="uninstall-linux" if="${not(platform::is-windows())}"/>
 		<call target="uninstall-win32" if="${platform::is-windows()}"/>
@@ -715,7 +712,7 @@
 		<property name="fakeroot.sharedmime" value="${fakeroot}/${sharedmime.prefix}" />
 		<property name="gsv.prefix" value="${pkg-config::get-variable(gsv.name,'prefix')}" />
 		<property name="fakeroot.gsv" value="${fakeroot}/${gsv.prefix}" />
-		
+
 		<foreach item="File" property="filename">
 		<in>
 			<items>
@@ -731,11 +728,11 @@
 			</exec>
 		</do>
 		</foreach>
-		
+
 		<delete dir="${fakeroot.boolib}" />
 		<delete dir="${fakeroot.boodocs}" />
 		<delete dir="${fakeroot.booexamples}" />
-		
+
 		<delete file="${fakeroot.sharedmime}/share/mime-info/boo.keys" />
 		<delete file="${fakeroot.sharedmime}/share/mime-info/boo.mime" />
 		<delete file="${fakeroot.gsv}/share/${gsv.name}/language-specs/boo.lang" />
@@ -745,17 +742,17 @@
 		<delete file="${fakeroot.bindir}/booc" />
 		<delete file="${fakeroot.bindir}/booish" />
 	</target>
-	
+
 	<target name="uninstall-win32">
 		<exec program='${ngen.exe}' if="${file::exists(ngen.exe)}" unless="${skip.ngen}">
 			<arg value='/delete' />
 			<arg value='Boo.Lang' />
-			<arg value='Boo.Lang.Compiler' />			
+			<arg value='Boo.Lang.Compiler' />
 			<arg value='Boo.Lang.Parser' />
 			<arg file='${build.dir}/booc.exe' />
 		</exec>
 	</target>
-	
+
 	<target name="Boo.Lang.Parser" depends="Boo.Lang.Compiler, compile-grammar, generate-errorpatterns">
 		<csc target="library"
 			output="${build.dir}/Boo.Lang.Parser.dll"
@@ -775,7 +772,7 @@
 			<arg line="/keyfile:${keyfile.path}" unless="${keyfile.path == ''}" />
 		</csc>
 	</target>
-	
+
 	<target name="insert-license" depends="core">
 		<insertLicense license="notice.txt">
 			<fileset basedir="src">
@@ -789,7 +786,7 @@
 			</fileset>
 		</insertLicense>
 	</target>
-	
+
 	<target name="upload-distro" depends="make-bin-dist">
 		<exec program="scp">
 			<arg value="-B" />
@@ -801,16 +798,16 @@
 			<arg value="${distro-user}@beaver.codehaus.org:/home/projects/boo/dist/distributions/" />
 		</exec>
 	</target>
-	
+
 	<target name="distro">
 		<call target="distro-win32" if="${platform::is-windows()}"/>
 		<call target="distro-linux" if="${not(platform::is-windows())}"/>
 	</target>
-	
+
 	<!-- Deprecated, now that binaries are built for multiple frameworks. -->
 	<target name="distro-linux" depends="src-distro">
 	</target>
-	
+
 	<!-- meant to be run on Windows with both .net 1.1 and .net 2.0 installed -->
 	<target name="distro-win32">
 		<fail unless="${nant.platform.win32}">
@@ -818,13 +815,13 @@
 		</fail>
 		<delete dir="${distrobuild.dir}" if="${directory::exists(distrobuild.dir)}" />
 		<mkdir dir="${distrobuild.dir}"/>
-		
-		<!-- We call nant externally so we can target multiple frameworks. -->		
+
+		<!-- We call nant externally so we can target multiple frameworks. -->
 		<exec program="${nant.location}/NAnt.exe">
 			<arg value="rebuild-and-update-bin" />
 			<arg value="-D:skip.vs=true" />
 		</exec>
-		
+
 		<!-- Here we actually build the zip files. -->
 		<call target="src-distro" />
 	</target>
@@ -833,13 +830,13 @@
 		<call target="rebuild" />
 		<call target="update-bin" />
 	</target>
-	
+
 	<target name="prepare-bin-distro" depends="insert-license">
 		<property name="distro.dir" value="${build.dir}/${boo.distro.name}" />
-		
+
 		<delete dir="${distro.dir}" if="${directory::exists(distro.dir)}" />
 		<mkdir dir="${distro.dir}" />
-		
+
 		<copy todir="${distro.dir}">
 			<fileset>
 				<include name="readme.txt" />
@@ -853,7 +850,7 @@
 				<include name="bin/**/*.rsp" />
 				<include name="bin/**/*.config" />
 				<include name="bin/**/*.targets" />
-				
+
 				<include name="extras/**/*.boo" />
 				<include name="extras/**/*.cs" />
 				<include name="extras/**/*.png" />
@@ -870,7 +867,7 @@
 				<include name="extras/SharpDevelop/**/*.xpt" />
 				<include name="extras/SharpDevelop/**/*.txtres" />
 				<include name="extras/SharpDevelop/**/*.addin" />
-				
+
 				<include name="examples/**/*.boo" />
 				<include name="examples/**/*.xml" />
 				<include name="examples/**/*.aspx" />
@@ -879,7 +876,7 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="bin-distro" depends="prepare-bin-distro">
 		<zip zipfile="${boo.distro.name}-bin.zip" ziplevel="9">
 			<fileset basedir="${distro.dir}">
@@ -887,10 +884,10 @@
 			</fileset>
 		</zip>
 	</target>
-	
+
 	<target name="prepare-src-distro" depends="bin-distro">
 		<copy todir="${distro.dir}">
-			<fileset>				
+			<fileset>
 				<include name="extras/*.in" />
 				<include name="default.build" />
 				<include name="notice.txt" />
@@ -901,7 +898,7 @@
 				<include name="Makefile.am" />
 				<include name="bin/Makefile.am" />
 				<include name="extras/Makefile.am" />
-				
+
 				<include name="${keyfile.path}" />
 				<include name="src/**/*.cs" />
 				<include name="src/**/*.boo" />
@@ -910,7 +907,7 @@
 				<include name="src/**/*.prjx" />
 				<include name="src/**/*.cmbx" />
 				<include name="src/**/*.targets" />
-				
+
 				<include name="tests/nunit.inc" />
 				<include name="tests/test.snk" />
 				<include name="tests/**/*.boo" />
@@ -921,14 +918,14 @@
 			</fileset>
 		</copy>
 	</target>
-	
+
 	<target name="src-distro" depends="prepare-src-distro">
 		<zip zipfile="${boo.distro.name}-src.zip" ziplevel="9">
 			<fileset basedir="${distro.dir}">
 				<include name="**" />
 			</fileset>
 		</zip>
-		
+
 		<tar destfile="${boo.distro.name}-src.tar.bz2" compression="BZip2">
 			<fileset basedir="${build.dir}">
 				<include name="${boo.distro.name}/**/*"/>
@@ -989,7 +986,7 @@
 	</target>
 
 	<target name="compile-grammar" depends="init" unless="${skip.antlr}">
-	
+
 		<uptodate property="parser-is-uptodate">
 			<sourcefiles basedir="src/Boo.Lang.Parser">
 				<include name="boo.g" />
@@ -1002,13 +999,13 @@
 		</uptodate>
 
 		<if test="${not parser-is-uptodate}">
-		
+
 			<delete>
 				<fileset basedir="src/Boo.Lang.Parser">
 					<include name="*TokenTypes.*" />
 				</fileset>
-			</delete>			 
-			
+			</delete>
+
 			<property name="antlr.traceParser" value="-traceParser" if="${antlr.trace}" />
 			<property name="antlr.traceParser" value="" unless="${antlr.trace}" />
 			<exec program="${java}" failonerror="true">
@@ -1020,7 +1017,7 @@
 				<arg value="src/Boo.Lang.Parser/" />
 				<arg value="src/Boo.Lang.Parser/boo.g" />
 			</exec>
-			
+
 			<exec program="${java}" failonerror="true">
 				<arg value="-cp" />
 				<arg file="${antlr.jar}" />
@@ -1029,19 +1026,19 @@
 				<arg value="src/Boo.Lang.Parser/" />
 				<arg value="src/Boo.Lang.Parser/booel.g" />
 			</exec>
-			
+
 			<touch file="src/Boo.Lang.Parser/BooParserBase.cs" />
 		</if>
 	</target>
-	
+
 	<target name="update-vs-env" unless="${skip.vs}">
 		<exec program="bin/booi.exe" failonerror="false" useruntimeengine="true">
 			<arg value="scripts/update-vs2005-env.boo" />
-		</exec>	
+		</exec>
 	</target>
-	
+
 	<target name="generate-ast" depends="init" unless="${skip.ast}">
-	
+
 		<uptodate property="ast-is-uptodate">
 			<sourcefiles>
 				<include name="ast.model.boo" />
@@ -1052,14 +1049,14 @@
 				<include name="src/Boo.Lang.Compiler/Ast/Impl/CompileUnitImpl.cs" />
 			</targetfiles>
 		</uptodate>
-				
+
 		<if test="${not ast-is-uptodate}">
 			<delete dir="src/Boo.Lang.Compiler/Ast/Impl"
 					if="${directory::exists('src/Boo.Lang.Compiler/Ast/Impl')}" />
 			<mkdir dir="src/Boo.Lang.Compiler/Ast/Impl" />
 			<exec program="bin/booi.exe" failonerror="false" useruntimeengine="true">
 				<arg value="scripts/astgen.boo" />
-			</exec>			
+			</exec>
 		</if>
 	</target>
 
@@ -1075,7 +1072,7 @@
 		</uptodate>
 
 		<if test="${not file::exists('build/booi.exe')}">
-			<echo level="Warning">WARNING: A recent version of Boo is required!</echo>  
+			<echo level="Warning">WARNING: A recent version of Boo is required!</echo>
 			<echo level="Warning">Run again Nant (without clean or rebuild) to actually generate the patterns</echo>
 			<property name="errorpatterns-are-uptodate" value="True" />
 		</if>
@@ -1088,8 +1085,8 @@
 				<arg value="scripts/error-patterns.boo" />
 			</exec>
 		</if>
-	</target>	
-	
+	</target>
+
 	<target name="update-sharpdevelop" depends="all">
 		<copy todir="${sharpdevelop.dir}/AddIns/AddIns/BackendBindings/BooBinding">
 			<fileset basedir="${build.dir}">
@@ -1098,21 +1095,21 @@
 			</fileset>
 		</copy>
 	</target>
-	
-	<target name="update-assembly-attributes" depends="core">	
+
+	<target name="update-assembly-attributes" depends="core">
 		<boo>
 		import System.IO
-		
+
 		fname = "src/Boo.Lang/Builtins.cs"
 		builtins = File.ReadAllText(fname)
-		
+
 		version = Project.Properties["boo.version"]
 		newBuiltins = @/new System.Version\(".+"\)/.Replace(builtins, "new System.Version(\"${version}.0\")")
 		if builtins != newBuiltins:
 			print fname
-			File.WriteAllText(fname, newBuiltins) 
+			File.WriteAllText(fname, newBuiltins)
 		</boo>
-		
+
     		<updateAssemblyVersion
 			version="${boo.assembly.version}">
 			<fileset basedir="src">
@@ -1123,7 +1120,7 @@
 				<include name="**/AssemblyInfo.boo" />
 			</fileset>
 		</updateAssemblyVersion>
-		
+
 		<updateAssemblyVersion
 			copyright="(C) 2003-2007 Rodrigo Barreto de Oliveira">
 			<fileset basedir="src">
@@ -1136,16 +1133,16 @@
 			</fileset>
 		</updateAssemblyVersion>
 	</target>
-	
+
 	<target name="rebuild" depends="clean">
-		
+
 		<touch file="ast.model.boo" />
 		<touch file="src/Boo.Lang.Parser/boo.g" />
 		<touch file="src/Boo.Lang.Parser/booel.g" />
 		<mkdir dir="${build.dir}" />
-		<call target="all" />		
+		<call target="all" />
 	</target>
-	
+
 	<target name="clean">
 		<delete dir="${build.dir}" failonerror="false" />
 	</target>
@@ -1156,7 +1153,7 @@
 		<property name="csc.define" value="${csc.define};IGNOREKEYFILE" unless="${nant-csc-keyfile-bug and not nosign}" />
 		<mkdir dir="${build.dir}" />
 	</target>
-	
+
 	<target name="makedeb" depends="rebuild">
 		<!-- force rebuild to make sure everything's ok and wrappers
 		     are sync'ed with current install.prefix

--- a/tests/testcases/integration/callables/callables-16.boo
+++ b/tests/testcases/integration/callables/callables-16.boo
@@ -1,11 +1,11 @@
-
+#category FailsOnMono4
 
 def foo():
 	return "foo"
-	
+
 def bar():
 	return "bar"
-	
+
 i = -1
 expected = "foo", "bar"
 for f in foo, bar:

--- a/tests/testcases/integration/callables/callables-39.boo
+++ b/tests/testcases/integration/callables/callables-39.boo
@@ -1,11 +1,11 @@
-
+#category FailsOnMono4
 
 def foo():
 	return "foo"
-	
+
 def bar():
 	return "bar"
-	
+
 a = foo, bar
 assert "foo" == a[0]()
 assert "bar" == a[-1]()

--- a/tests/testcases/integration/callables/callables-41.boo
+++ b/tests/testcases/integration/callables/callables-41.boo
@@ -1,5 +1,5 @@
+#category FailsOnMono4
 
-	
 a = { return "foo" }, { return "bar" }
 assert "foo" == a[0]()
 assert "bar" == a[-1]()

--- a/tests/testcases/integration/callables/callables-43.boo
+++ b/tests/testcases/integration/callables/callables-43.boo
@@ -1,5 +1,5 @@
+#category FailsOnMono4
 
-	
 a = { item | return item.ToString() }, { item as string | return item.ToUpper() }
 
 assert "3" == a[0](3)

--- a/tests/testcases/integration/callables/params-7.boo
+++ b/tests/testcases/integration/callables/params-7.boo
@@ -1,3 +1,4 @@
+#category FailsOnMono4
 """
 3
 2
@@ -9,10 +10,10 @@ callable Function(*args)
 
 def foo(*args):
 	print len(args)
-	
+
 def bar(args as (object)):
 	print join(args)
-	
+
 for item in foo, bar:
 	f as Function = item
 	f(1, 2, 3)

--- a/tests/testcases/integration/generators/generators-17.boo
+++ b/tests/testcases/integration/generators/generators-17.boo
@@ -1,3 +1,4 @@
+#category FailsOnMono4
 import System
 
 

--- a/tests/testcases/net2/generics/generic-list-of-callable.boo
+++ b/tests/testcases/net2/generics/generic-list-of-callable.boo
@@ -1,3 +1,4 @@
+#category FailsOnMono4
 """
 Boo.Lang.List`1[TestFuncs.MyCallable]
 """
@@ -7,5 +8,5 @@ callable MyCallable(i as int) as MyCallable
 
 class MyClass:
 	public list = List[of MyCallable]()
-		
+
 print MyClass().list.GetType()


### PR DESCRIPTION
Trying to run the unit tests under Mono 4.2.0 (OS X) a bunch of them were failing. I haven't dig down on what's the reason but I guess we can mark them in the mean time.

To exclude these tests when running under Mono: `-exclude=FailsOnMono,FailsOnMono4`

**Update 22-Dec**: There were some issues making the build compatible with Travis and OS X when using Mono 3.12. As part of this PR Travis will run the build on Mono 4.20.1 which fixes that compatibility.