### PR TITLE
Fixing issue #143

### DIFF
--- a/src/Boo.Lang.Compiler/Ast/AstNodePredicates.cs
+++ b/src/Boo.Lang.Compiler/Ast/AstNodePredicates.cs
@@ -17,6 +17,14 @@ namespace Boo.Lang.Compiler.Ast
 			return node == parentExpression.Left && AstUtil.IsAssignment(parentExpression);
 		}
 
+		public static bool IsTargetOfMethodInvocation(this Expression node)
+		{
+			var parentExpression = node.ParentNode as MethodInvocationExpression;
+			if (parentExpression == null)
+				return false;
+			return node == parentExpression.Target;
+		}
+
 		public static bool IsComplexSlice(Slice slice)
 		{
 			return slice.End != null

--- a/src/Boo.Lang.Compiler/Steps/CheckMembersProtectionLevel.cs
+++ b/src/Boo.Lang.Compiler/Steps/CheckMembersProtectionLevel.cs
@@ -50,10 +50,35 @@ namespace Boo.Lang.Compiler.Steps
 		{
 			base.OnMemberReferenceExpression(node);
 
-			OnReferenceExpression(node);
+			OnExpression(node);
 		}
-		
+
 		override public void OnReferenceExpression(ReferenceExpression node)
+		{
+			OnExpression(node);
+		}
+
+		override public void OnSelfLiteralExpression(SelfLiteralExpression node)
+		{
+			base.OnSelfLiteralExpression(node);
+			
+			if (node.IsTargetOfMethodInvocation())
+			{
+				OnExpression(node);
+			}
+		}
+
+		override public void OnSuperLiteralExpression(SuperLiteralExpression node)
+		{
+			base.OnSuperLiteralExpression(node);
+			
+			if (node.IsTargetOfMethodInvocation())
+			{
+				OnExpression(node);
+			}
+		}
+
+		private void OnExpression(Expression node)
 		{
 			var member = node.Entity as IAccessibleMember;
 			if (null == member) return;


### PR DESCRIPTION
Ensuring that `CheckMembersProtectionLevel` will visit `self` and
`super` method references (constructors) correctly.