### PR TITLE
Remote master with booish fixes

### DIFF
--- a/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
+++ b/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
@@ -476,7 +476,6 @@ class InteractiveInterpreterConsole:
 
 		if newLine:
 			_multiline = false
-			# Qui mi sposto a capo di uno, devo spostarmi prima sull'ultima riga scritta
 			last_line = Top((len(CurrentPrompt) + LineLen),Console.WindowWidth)
 			Console.CursorTop = originalYPosition + last_line -1
 			Console.Write(Environment.NewLine)

--- a/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
+++ b/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
@@ -259,11 +259,15 @@ class InteractiveInterpreterConsole:
 		_indent--
 
 	protected def Delete(count as int): #if count is 0, forward-delete
+		return if LineLen == 0
 		cx = Console.CursorLeft+(Console.CursorTop-originalYPosition)*Console.WindowWidth-len(CurrentPrompt)-count
-		return if cx < len(CurrentPrompt) and count == 0 		
+		//return if cx < len(CurrentPrompt) and count == 0
+		count = 1 if cx >= LineLen and count == 0
+		return if cx >= LineLen
 		dcount = (count if count != 0 else 1)
 		_line.Remove(cx, dcount)
-		curX = Console.CursorLeft - dcount
+		//curX = Console.CursorLeft - dcount
+		curX = Console.CursorLeft - count
 		curY = Console.CursorTop
 		if curX < 0:
 			curX = Console.WindowWidth-1

--- a/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
+++ b/src/Boo.Lang.Interpreter/InteractiveInterpreterConsole.boo
@@ -476,6 +476,9 @@ class InteractiveInterpreterConsole:
 
 		if newLine:
 			_multiline = false
+			# Qui mi sposto a capo di uno, devo spostarmi prima sull'ultima riga scritta
+			last_line = Top((len(CurrentPrompt) + LineLen),Console.WindowWidth)
+			Console.CursorTop = originalYPosition + last_line -1
 			Console.Write(Environment.NewLine)
 
 			if not TryRunCommand(Line):


### PR DESCRIPTION
This PR solves the problem about HOME key + ENTER overwriting lines in multiline commands as depicted in #141 and also implement fix suggested for DEL key behavior from issue #57 .

