### PR TITLE
Ensure test case directories are created

### DIFF
--- a/tests/generate_regression.boo
+++ b/tests/generate_regression.boo
@@ -302,8 +302,10 @@ def MapPath(path):
 	return Path.GetFullPath(path)
 
 def WriteTestCases(writer as TextWriter, baseDir as string):
-	count, ignored = 0, 0
-	for fname as string in Directory.GetFiles(MapPath("testcases/${baseDir}")):
+	count, ignored = 0, 0;
+	testCasePath = MapPath("testcases/${baseDir}");
+	System.IO.Directory.CreateDirectory(testCasePath);
+	for fname as string in Directory.GetFiles(testCasePath):
 		continue unless fname.EndsWith(".boo")
 		attribute = CategoryAttributeFor(fname)
 		


### PR DESCRIPTION
The Travis build is [currently failing](https://travis-ci.org/boo-lang/boo/builds/193998291) because tests/generate_regression.boo is attempting to generate files into a directory that doesn't exist. This change ensures that test case directories are created before test case files are generated.