### PR TITLE
Fix more compiler defects

### DIFF
--- a/src/Boo.Lang.Compiler/Ast/Visitors/BooPrinterVisitor.cs
+++ b/src/Boo.Lang.Compiler/Ast/Visitors/BooPrinterVisitor.cs
@@ -693,7 +693,8 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 		
 		override public void OnUnaryExpression(UnaryExpression node)
 		{
-			bool addParens = NeedParensAround(node) && !IsMethodInvocationArg(node) && node.Operator != UnaryOperatorType.SafeAccess;
+			bool addParens = NeedParensAround(node) && !IsMethodInvocationArg(node) && node.Operator != UnaryOperatorType.SafeAccess
+				&& !StartsMacroArguments(node);
 			if (addParens)
 			{
 				Write("(");
@@ -713,6 +714,30 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 			{
 				Write(")");
 			}
+		}
+
+		private MacroStatement _macroBeingPrinted;
+
+		// A paren opening a macro's arguments reads back as its argument list,
+		// leaving what follows dangling: "assert (-1) == 1" returns as a call.
+		// Unary only: NeedParensAround is precedence blind, so dropping a
+		// binary's parens here would reassociate what it printed.
+		private bool StartsMacroArguments(UnaryExpression e)
+		{
+			if (_macroBeingPrinted == null)
+				return false;
+
+			Node child = e;
+			for (Node parent = e.ParentNode; parent != null; child = parent, parent = parent.ParentNode)
+			{
+				if (parent == _macroBeingPrinted)
+					return _macroBeingPrinted.Arguments.Count > 0 && _macroBeingPrinted.Arguments[0] == child;
+
+				var binary = parent as BinaryExpression;
+				if (binary == null || binary.Left != child)
+					return false;
+			}
+			return false;
 		}
 
 		private bool IsMethodInvocationArg(UnaryExpression node)
@@ -1097,7 +1122,10 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 		{
 			WriteIndented(node.Name);
 			Write(" ");
+			var enclosing = _macroBeingPrinted;
+			_macroBeingPrinted = node;
 			WriteCommaSeparatedList(node.Arguments);
+			_macroBeingPrinted = enclosing;
 			if (!node.Body.IsEmpty)
 			{
 				WriteLine(":");

--- a/src/Boo.Lang.Compiler/Ast/Visitors/BooPrinterVisitor.cs
+++ b/src/Boo.Lang.Compiler/Ast/Visitors/BooPrinterVisitor.cs
@@ -31,6 +31,7 @@ using System.Text.RegularExpressions;
 using System.Globalization;
 using System.IO;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Boo.Lang.Compiler.Ast.Visitors
 {
@@ -372,6 +373,12 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 							return false;
 						case NodeType.TryStatement:
 							return false;
+						case NodeType.UnlessStatement:
+							return false;
+						// print and the like are macros too, so go by whether the
+						// macro carries a block the brace form cannot hold.
+						case NodeType.MacroStatement:
+							return ((MacroStatement)node.Body.Statements[0]).Body.IsEmpty;
 					}
 					return true;
 
@@ -775,11 +782,34 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 			WriteLine();
 		}
 
+		/// <summary>
+		/// A multi statement closure the printer cannot write inline, sitting in
+		/// the last argument of a call that is itself a statement. Boo writes that
+		/// as a trailing block, and nothing else parses.
+		/// </summary>
+		private BlockExpression TrailingBlockArgument(MethodInvocationExpression e)
+		{
+			if (!(e.ParentNode is ExpressionStatement))
+				return null;
+			if (e.NamedArguments.Count > 0 || e.Arguments.Count == 0)
+				return null;
+
+			var last = e.Arguments[e.Arguments.Count - 1] as BlockExpression;
+			if (null == last || last.Parameters.Count > 0 || IsSimpleClosure(last))
+				return null;
+			return last;
+		}
+
 		override public void OnMethodInvocationExpression(MethodInvocationExpression e)
 		{
+			var trailing = TrailingBlockArgument(e);
+
 			Visit(e.Target);
 			Write("(");
-			WriteCommaSeparatedList(e.Arguments);
+			IEnumerable<Expression> args = e.Arguments;
+			if (trailing != null)
+				args = e.Arguments.Take(e.Arguments.Count - 1);
+			WriteCommaSeparatedList(args);
 			if (e.NamedArguments.Count > 0)
 			{
 				if (e.Arguments.Count > 0)
@@ -789,6 +819,12 @@ namespace Boo.Lang.Compiler.Ast.Visitors
 				WriteCommaSeparatedList(e.NamedArguments);
 			}
 			Write(")");
+
+			if (trailing != null)
+			{
+				WriteLine(":");
+				WriteBlock(trailing.Body);
+			}
 		}
 		
 		override public void OnArrayLiteralExpression(ArrayLiteralExpression node)

--- a/src/Boo.Lang.Compiler/Steps/Inheritance/BaseTypeResolution.cs
+++ b/src/Boo.Lang.Compiler/Steps/Inheritance/BaseTypeResolution.cs
@@ -64,6 +64,16 @@ namespace Boo.Lang.Compiler.Steps.Inheritance
 			}
 		}
 
+		// A constraint can name the base this type extends, so bind constraints
+		// first: base type binding asks whether they are satisfied.
+		private void ResolveGenericParameterConstraints()
+		{
+			foreach (var parameter in _typeDefinition.GenericParameters)
+				foreach (var constraint in parameter.BaseTypes.ToArray())
+					if (constraint.Entity == null)
+						NameResolutionService.ResolveTypeReference(constraint);
+		}
+
 		private INamespace ParentNamespaceOf(TypeDefinition typeDefinition)
 		{
 			return (INamespace) GetEntity(typeDefinition.ParentNode);
@@ -89,6 +99,8 @@ namespace Boo.Lang.Compiler.Steps.Inheritance
 				visitedInterfaces = new List<TypeDefinition>();
 			}
 			
+			ResolveGenericParameterConstraints();
+
 			foreach (var baseTypeRef in _typeDefinition.BaseTypes.ToArray())
 			{
 				NameResolutionService.ResolveTypeReference(baseTypeRef);

--- a/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericConstructionChecker.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericConstructionChecker.cs
@@ -112,11 +112,18 @@ namespace Boo.Lang.Compiler.TypeSystem.Generics
 		}
 
 		IType _definition;
+		TypeMapper _constraintMapper;
 
 		private bool MaintainsParameterConstraints(IEntity definition)
 		{
 			IGenericParameter[] parameters = GenericsServices.GetGenericParameters(definition);
 			_definition = definition as IType;
+			// Constraints are declared against the definition's own parameters, so
+			// they must be substituted before asking whether an argument fits.
+			var constraintMapper = new TypeReplacer();
+			for (int i = 0; i < parameters.Length && i < TypeArguments.Length; ++i)
+				constraintMapper.Replace(parameters[i], TypeArguments[i]);
+			_constraintMapper = constraintMapper;
 
 			bool valid = true;
 			for (int i = 0; i < parameters.Length; i++)
@@ -163,11 +170,14 @@ namespace Boo.Lang.Compiler.TypeSystem.Generics
 			IType[] baseTypes = parameter.GetTypeConstraints();
 			if (baseTypes != null)
 			{
-				foreach (IType baseType in baseTypes)
+				foreach (IType declaredBaseType in baseTypes)
 				{
-					// Foo<T> where T : Foo<T>
+					var baseType = _constraintMapper.MapType(declaredBaseType);
+
+					// Foo<T> where T : Foo<T>, asked while the type being
+					// declared is still binding its own base.
 					if (null != _definition
-					    && TypeCompatibilityRules.IsAssignableFrom(baseType, _definition)
+					    && TypeCompatibilityRules.IsAssignableFrom(declaredBaseType, _definition)
 					    && argument == _constructionNode.ParentNode.Entity)
 						continue;
 

--- a/src/Boo.Lang.Parser/BooParser.g4.cs
+++ b/src/Boo.Lang.Parser/BooParser.g4.cs
@@ -43,8 +43,12 @@ partial class BooParser
 	private static bool IsValidMacroArgument(int tokenType) =>
 		LPAREN != tokenType && LBRACK != tokenType && DOT != tokenType && MULTIPLY != tokenType;
 
+	// A name that runs straight into the end of the closure or the end of the
+	// statement has no argument after it, so it is the value the closure
+	// yields rather than a macro to invoke.
 	protected bool IsValidClosureMacroArgument(int tokenType) =>
-		IsValidMacroArgument(tokenType) && SUBTRACT != tokenType;
+		IsValidMacroArgument(tokenType) && SUBTRACT != tokenType
+		&& RBRACE != tokenType && EOS != tokenType;
 
 	public static CompileUnit ParseReader(Boo.Lang.Parser.ParserSettings settings, string readerName, TextReader reader)
 	{

--- a/tests/Boo.Lang.Parser.Tests/ParserRoundtripTestFixture.cs
+++ b/tests/Boo.Lang.Parser.Tests/ParserRoundtripTestFixture.cs
@@ -817,6 +817,12 @@ namespace Boo.Lang.Parser.Tests
 		}
 		
 		[Test]
+		public void macro_argument_parens_1()
+		{
+			RunCompilerTestCase(@"macro-argument-parens-1.boo");
+		}
+		
+		[Test]
 		public void macros_1()
 		{
 			RunCompilerTestCase(@"macros-1.boo");

--- a/tests/Boo.Lang.Parser.Tests/ParserRoundtripTestFixture.cs
+++ b/tests/Boo.Lang.Parser.Tests/ParserRoundtripTestFixture.cs
@@ -229,6 +229,12 @@ namespace Boo.Lang.Parser.Tests
 		}
 		
 		[Test]
+		public void closure_printing_1()
+		{
+			RunCompilerTestCase(@"closure-printing-1.boo");
+		}
+		
+		[Test]
 		public void closures_1()
 		{
 			RunCompilerTestCase(@"closures-1.boo");

--- a/tests/BooCompiler.Tests/ClosuresIntegrationTestFixture.cs
+++ b/tests/BooCompiler.Tests/ClosuresIntegrationTestFixture.cs
@@ -199,6 +199,12 @@ namespace BooCompiler.Tests
 		}
 		
 		[Test]
+		public void closures_32()
+		{
+			RunCompilerTestCase(@"closures-32.boo");
+		}
+		
+		[Test]
 		public void closures_4()
 		{
 			RunCompilerTestCase(@"closures-4.boo");

--- a/tests/BooCompiler.Tests/GenericsTestFixture.cs
+++ b/tests/BooCompiler.Tests/GenericsTestFixture.cs
@@ -573,6 +573,12 @@ namespace BooCompiler.Tests
 			RunCompilerTestCase(@"naked-type-constraints-1.boo");
 		}
 		
+		[Test]
+		public void self_constrained_base_1()
+		{
+			RunCompilerTestCase(@"self-constrained-base-1.boo");
+		}
+		
 		[Ignore("generics with nested types not supported yet")][Test]
 		public void nested_generic_type_1()
 		{

--- a/tests/testcases/integration/closures/closures-32.boo
+++ b/tests/testcases/integration/closures/closures-32.boo
@@ -1,0 +1,39 @@
+# A closure picks between a macro call and a plain expression by looking at
+# the token after the name. A name running straight into the closing brace,
+# or into a statement separator, has nothing left to be its argument, so it
+# is a value rather than a macro to invoke.
+x = 42
+byName = { x }
+assert 42 == byName()
+
+identity = { p as int | p }
+assert 7 == identity(7)
+
+untyped = { p | p }
+assert "boo" == untyped("boo")
+
+# The name reached the separator rather than the brace.
+separated = { x; }
+assert 42 == separated()
+
+# A name with an argument after it is still the macro it always was.
+calls = []
+appends = { calls.Add("a") }
+appends()
+appends()
+assert 2 == len(calls)
+
+twice = { calls.Add("b"); calls.Add("c") }
+twice()
+assert 4 == len(calls)
+
+# The guards that were already there still hold: a call, an index, a member
+# and a negation are none of them the start of a macro argument.
+def three() as int:
+	return 3
+assert 3 == { three() }()
+items = (10, 20)
+assert 10 == { items[0] }()
+assert 3 == { "abc".Length }()
+negated = { -1 }
+assert negated() == -1

--- a/tests/testcases/net2/errors/BCE0149-4.boo
+++ b/tests/testcases/net2/errors/BCE0149-4.boo
@@ -1,5 +1,5 @@
 """
-BCE0149-4.boo(8,12): BCE0149: The type 'string' must derive from 'Test[of T]' in order to substitute the generic parameter 'T' in 'Test[of T]'.
+BCE0149-4.boo(8,12): BCE0149: The type 'string' must derive from 'Test[of string]' in order to substitute the generic parameter 'T' in 'Test[of T]'.
 """
 
 class Test [of T(Test[of T])]:

--- a/tests/testcases/net2/generics/self-constrained-base-1.boo
+++ b/tests/testcases/net2/generics/self-constrained-base-1.boo
@@ -1,0 +1,22 @@
+"""
+GenericSelf`1[Leaf]
+GenericSelf`2[Leaf,System.Int32]
+Narrowed`1[Leaf]
+"""
+# A derived generic that repeats its base's self constraint and extends it.
+
+abstract class GenericSelf[of T(GenericSelf[of T])]:
+	pass
+
+abstract class GenericSelf[of T(GenericSelf[of T]), S(struct)](GenericSelf[of T]):
+	pass
+
+abstract class Narrowed[of T(GenericSelf[of T])](GenericSelf[of T]):
+	pass
+
+class Leaf(GenericSelf[of Leaf]):
+	pass
+
+print typeof(GenericSelf[of Leaf])
+print typeof(GenericSelf[of Leaf, int])
+print typeof(Narrowed[of Leaf])

--- a/tests/testcases/parser/roundtrip/closure-printing-1.boo
+++ b/tests/testcases/parser/roundtrip/closure-printing-1.boo
@@ -1,0 +1,34 @@
+"""
+import System
+import System.IO
+
+def Run(action as Action):
+	action()
+
+Run():
+	print 'a'
+	print 'b'
+
+NeedsHeader = def (path as string) as bool:
+	using reader = StringReader(path):
+		return (reader.ReadLine() is not null)
+
+print NeedsHeader('x')
+"""
+import System
+import System.IO
+
+def Run(action as Action):
+	action()
+
+# A closure carrying a block cannot be written inline, and one passed as the
+# last argument of a call statement has to be printed as a trailing block.
+Run():
+	print "a"
+	print "b"
+
+NeedsHeader = def(path as string) as bool:
+	using reader = StringReader(path):
+		return reader.ReadLine() is not null
+
+print NeedsHeader("x")

--- a/tests/testcases/parser/roundtrip/macro-argument-parens-1.boo
+++ b/tests/testcases/parser/roundtrip/macro-argument-parens-1.boo
@@ -1,0 +1,10 @@
+"""
+assert -1 == (-1)
+print -1 == (-1)
+assert -x == 3
+"""
+# A paren opening a macro's arguments reads back as its argument list, so
+# "assert (-1) == (-1)" would return from the parser as a call to assert.
+assert -1 == -1
+print -1 == -1
+assert -x == 3


### PR DESCRIPTION
# fix: four compiler defects, each with a regression test

Four independent fixes, found while writing ordinary Boo against the compiler.
Every commit builds and tests green on its own.

## Printer: closures in an argument list did not survive a reprint

A closure whose single statement carries a block was treated as simple and
flattened into braces, losing every statement separator. A multi-statement
closure passed as an argument printed as `f(a, def ():` with the closing paren
at column 0, which is not Boo. That case now prints as a trailing block, `f(a):`.

## Parser: a lone name as a closure body was parsed as a call

`{ x }` compiled to `x()`. The lookahead predicate that picks the macro path
accepted the closure's own `}` as the start of an argument. Now excludes
`RBRACE` and `EOS`.

## Printer: a paren opening a macro's arguments changed the parse

`assert -1 == -1` printed as `assert (-1) == (-1)`, which reads back as a call
to `assert` with the comparison left dangling. Suppressed for unary operands
only: they bind tighter than every binary operator, so their parens are never
carrying binding.

## Generics: constraints were checked without substitution

Constraints are declared against the definition's own parameters, so
`Base[of Base.T]` was compared verbatim against an argument constrained to
`Base[of Derived.T]`. A generic that repeats its base's self constraint — the
form C# requires to make it legal — hit BCE0015, an internal error rather than
a diagnostic. Constraints are now substituted before checking, and bound before
base types.

## Behaviour changes

- `{ print }` was a no-argument call emitting a blank line; it is now a
  reference and does nothing. Token lookahead cannot tell it from `{ x }` —
  write `{ print() }` for the call.
- `BCE0149` now names the substituted constraint, `Test[of string]` rather than
  `Test[of T]`, matching C#. `BCE0149-4.boo` updates with it.

## Testing

Four new testcases, one updated expectation, the rest compiler.

Each commit was checked out clean and run through `dotnet build Boo.slnx`,
`dotnet test Boo.slnx`, and `--filter "TestCategory=Corpus"`, all in Release.
Green at every commit, and each new test confirmed red with only its own fix
reverted.
