### PR TITLE
Feat: boo decompiler and other LSP pre-reqs

### DIFF
--- a/Boo.slnx
+++ b/Boo.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/Boo.Lang.PatternMatching/Boo.Lang.PatternMatching.booproj" Type="C#" />
     <Project Path="src/Boo.Lang.Useful/Boo.Lang.Useful.booproj" Type="C#" />
     <Project Path="src/Boo.Lang.Interpreter/Boo.Lang.Interpreter.booproj" Type="C#" />
+    <Project Path="src/Boo.Lang.Decompiler/Boo.Lang.Decompiler.booproj" Type="C#" />
     <Project Path="src/Boo.Lang.CodeDom/Boo.Lang.CodeDom.booproj" Type="C#" />
     <Project Path="src/Boo.Microsoft.Build.Tasks/Boo.Microsoft.Build.Tasks.booproj" Type="C#" />
     <Project Path="src/booi/booi.booproj" Type="C#" />
@@ -27,6 +28,7 @@
     <Project Path="tests/Boo.Lang.CodeDom.Tests/Boo.Lang.CodeDom.Tests.booproj" Type="C#" />
     <Project Path="tests/Boo.Lang.PatternMatching.Tests/Boo.Lang.PatternMatching.Tests.booproj" Type="C#" />
     <Project Path="tests/Boo.Lang.Interpreter.Tests/Boo.Lang.Interpreter.Tests.booproj" Type="C#" />
+    <Project Path="tests/Boo.Lang.Decompiler.Tests/Boo.Lang.Decompiler.Tests.booproj" Type="C#" />
     <Project Path="tests/Boo.Lang.Useful.Tests/Boo.Lang.Useful.Tests.booproj" Type="C#" />
   </Folder>
 </Solution>

--- a/Boo.targets
+++ b/Boo.targets
@@ -85,7 +85,9 @@
 
     <MakeDir Directories="$(ProjectDir)$(IntermediateOutputPath)" />
 
-    <Exec Command="dotnet &quot;$(BoocDll)&quot; -noconfig -target:$(_BooTargetKind) -out:&quot;$(_BooOutput)&quot; @(_BooReference->'-r:&quot;%(FullPath)&quot;', ' ') @(BooCompile->'&quot;%(FullPath)&quot;', ' ')"
+    <!-- Every reference is passed below, so the implicit Boo.Lang.Extensions
+         is only in the way: it collides when compiling Extensions itself. -->
+    <Exec Command="dotnet &quot;$(BoocDll)&quot; -noconfig -noextensions -target:$(_BooTargetKind) -out:&quot;$(_BooOutput)&quot; @(_BooReference->'-r:&quot;%(FullPath)&quot;', ' ') @(BooCompile->'&quot;%(FullPath)&quot;', ' ')"
           StandardOutputImportance="normal" />
 
     <ItemGroup>

--- a/src/Boo.Lang.Compiler/CompilerParameters.cs
+++ b/src/Boo.Lang.Compiler/CompilerParameters.cs
@@ -333,6 +333,18 @@ namespace Boo.Lang.Compiler
 					fullLog += ff.FusionLog;
 					continue;
 				}
+				// A file of that name that will not load is no more an answer
+				// than no file at all, and throwing here ignores throwOnError.
+				catch (FileLoadException fl)
+				{
+					fullLog += fl.FusionLog;
+					continue;
+				}
+				catch (BadImageFormatException bf)
+				{
+					fullLog += bf.FusionLog;
+					continue;
+				}
 			}
 			if (throwOnError)
 			{

--- a/src/Boo.Lang.Compiler/CompilerParameters.cs
+++ b/src/Boo.Lang.Compiler/CompilerParameters.cs
@@ -132,13 +132,25 @@ namespace Boo.Lang.Compiler
 
 		public void LoadDefaultReferences()
 		{
+			LoadDefaultReferences(true);
+		}
+
+		/// <summary>
+		/// Loads the standard references, optionally without Boo.Lang.Extensions.
+		/// </summary>
+		/// <remarks>
+		/// Compiling Boo.Lang.Extensions itself has to leave it out: the loaded
+		/// copy's macros collide with the ones being compiled.
+		/// </remarks>
+		public void LoadDefaultReferences(bool loadExtensions)
+		{
 			//boo.lang.dll
 			_booAssembly = typeof(Builtins).Assembly;
 			_compilerReferences.Add(_booAssembly);
 
 			//boo.lang.extensions.dll
 			//try loading extensions next to Boo.Lang (in the same directory)
-			var extensionsAssembly = TryToLoadExtensionsAssembly();
+			var extensionsAssembly = loadExtensions ? TryToLoadExtensionsAssembly() : null;
 			if (extensionsAssembly != null)
 				_compilerReferences.Add(extensionsAssembly);
 

--- a/src/Boo.Lang.Decompiler/Bodies.boo
+++ b/src/Boo.Lang.Decompiler/Bodies.boo
@@ -1,0 +1,349 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace Boo.Lang.Decompiler
+
+import System
+import System.Text
+import ICSharpCode.Decompiler.CSharp.Syntax
+
+internal class Bodies:
+"""
+Converts a decompiled method body to Boo.
+
+C# with no Boo equivalent becomes a "# TODO" comment holding the original,
+so nothing is silently dropped. The output is for reading, not compiling.
+"""
+
+	static def Of(block as BlockStatement, indent as string) as string:
+		return "${indent}pass\n" if block is null or block.IsNull
+		written = Statements(block, indent)
+		return "${indent}pass\n" if string.IsNullOrEmpty(written)
+		return written
+
+	private static def Statements(block as BlockStatement, indent as string) as string:
+		written = StringBuilder()
+		for statement in block.Statements:
+			written.Append(Statement(statement, indent))
+		return written.ToString()
+
+	private static def Statement(node as Statement, indent as string) as string:
+		return "" if node is null or node isa EmptyStatement
+
+		block = node as BlockStatement
+		return Statements(block, indent) if block is not null
+
+		returned = node as ReturnStatement
+		if returned is not null:
+			return "${indent}return\n" if returned.Expression.IsNull
+			return "${indent}return ${Value(returned.Expression)}\n"
+
+		expressed = node as ExpressionStatement
+		return "${indent}${Value(expressed.Expression)}\n" if expressed is not null
+
+		declared = node as VariableDeclarationStatement
+		return Declaration(declared, indent) if declared is not null
+
+		branch = node as IfElseStatement
+		return Branch(branch, indent) if branch is not null
+
+		loop = node as WhileStatement
+		return "${indent}while ${Value(loop.Condition)}:\n${Nested(loop.EmbeddedStatement, indent)}" if loop is not null
+
+		each = node as ForeachStatement
+		if each is not null:
+			return "${indent}for ${each.VariableDesignation} in ${Value(each.InExpression)}:\n${Nested(each.EmbeddedStatement, indent)}"
+
+		thrown = node as ThrowStatement
+		if thrown is not null:
+			return "${indent}raise\n" if thrown.Expression.IsNull
+			return "${indent}raise ${Value(thrown.Expression)}\n"
+
+		guarded = node as TryCatchStatement
+		return Guarded(guarded, indent) if guarded is not null
+
+		held = node as UsingStatement
+		if held is not null:
+			return "${indent}using ${Value(held.ResourceAcquisition as Expression)}:\n${Nested(held.EmbeddedStatement, indent)}" if held.ResourceAcquisition isa Expression
+			return Unwritten(node, indent)
+
+		counted = node as ForStatement
+		return Counted(counted, indent) if counted is not null
+
+		chosen = node as SwitchStatement
+		return Chosen(chosen, indent) if chosen is not null
+
+		repeated = node as DoWhileStatement
+		if repeated is not null:
+			# Boo has no do while, so the test moves to the end of the body.
+			body = Nested(repeated.EmbeddedStatement, indent)
+			return "${indent}while true:\n${body}${indent}\tbreak unless ${Value(repeated.Condition)}\n"
+
+		return "${indent}break\n" if node isa BreakStatement
+		return "${indent}continue\n" if node isa ContinueStatement
+
+		return Unwritten(node, indent)
+
+	private static def Chosen(chosen as SwitchStatement, indent as string) as string:
+	"""
+	A switch as an if/elif chain, since Boo has no switch.
+
+	The break ending each section only exits the switch, which the chain
+	does anyway, so it is dropped.
+	"""
+		written = StringBuilder()
+		subject = Value(chosen.Expression)
+		first = true
+		fallen = StringBuilder()
+		for section as SwitchSection in chosen.SwitchSections:
+			test = Test(subject, section)
+			body = Section(section, indent)
+			if test is null:
+				fallen.Append(indent).Append("else:\n").Append(body)
+				continue
+			written.Append(indent).Append(("if " if first else "elif ")).Append(test).Append(":\n")
+			written.Append(body)
+			first = false
+		written.Append(fallen.ToString())
+		return written.ToString()
+
+	private static def Test(subject as string, section as SwitchSection) as string:
+	"""The condition for a section, or null for the default one."""
+		tests = System.Collections.Generic.List[of string]()
+		for label as CaseLabel in section.CaseLabels:
+			return null if label.Expression.IsNull
+			tests.Add("${subject} == ${Value(label.Expression)}")
+		return null if tests.Count == 0
+		return string.Join(" or ", tests.ToArray())
+
+	private static def Section(section as SwitchSection, indent as string) as string:
+		written = StringBuilder()
+		for statement as Statement in section.Statements:
+			continue if statement isa BreakStatement
+			written.Append(Statement(statement, indent + "\t"))
+		return "${indent}\tpass\n" if written.Length == 0
+		return written.ToString()
+
+	private static def Guarded(guarded as TryCatchStatement, indent as string) as string:
+		written = StringBuilder()
+		written.Append(indent).Append("try:\n").Append(Nested(guarded.TryBlock, indent))
+		for caught as CatchClause in guarded.CatchClauses:
+			written.Append(indent).Append("except")
+			unless caught.Type.IsNull:
+				name = (caught.VariableName if not string.IsNullOrEmpty(caught.VariableName) else "e")
+				written.Append(" ").Append(name).Append(" as ").Append(Decompiled.BooType(caught.Type))
+			written.Append(":\n").Append(Nested(caught.Body, indent))
+		unless guarded.FinallyBlock.IsNull:
+			written.Append(indent).Append("ensure:\n").Append(Nested(guarded.FinallyBlock, indent))
+		return written.ToString()
+
+	private static def Counted(counted as ForStatement, indent as string) as string:
+	"""
+	A C# for loop as a while, since Boo has no three part for.
+
+	The setup runs before the loop and the step at the end of the body. A
+	continue would skip that step, so those loops are left unconverted.
+	"""
+		return Unwritten(counted, indent) if Continues(counted.EmbeddedStatement)
+		written = StringBuilder()
+		for setup as Statement in counted.Initializers:
+			written.Append(Statement(setup, indent))
+		written.Append(indent).Append("while ").Append(Value(counted.Condition)).Append(":\n")
+		written.Append(Nested(counted.EmbeddedStatement, indent))
+		for step as Statement in counted.Iterators:
+			written.Append(Statement(step, indent + "\t"))
+		return written.ToString()
+
+	private static def Continues(node as AstNode) as bool:
+		return true if node isa ContinueStatement
+		for child in node.Children:
+			return true if Continues(child)
+		return false
+
+	private static def Declaration(declared as VariableDeclarationStatement, indent as string) as string:
+		written = StringBuilder()
+		for variable as VariableInitializer in declared.Variables:
+			written.Append(indent).Append(variable.Name)
+			if variable.Initializer.IsNull:
+				written.Append(" as ").Append(Decompiled.BooType(declared.Type)).Append("\n")
+			else:
+				written.Append(" = ").Append(Value(variable.Initializer)).Append("\n")
+		return written.ToString()
+
+	private static def Branch(branch as IfElseStatement, indent as string) as string:
+		written = StringBuilder()
+		written.Append(indent).Append("if ").Append(Value(branch.Condition)).Append(":\n")
+		written.Append(Nested(branch.TrueStatement, indent))
+		unless branch.FalseStatement.IsNull:
+			written.Append(indent).Append("else:\n")
+			written.Append(Nested(branch.FalseStatement, indent))
+		return written.ToString()
+
+	private static def Nested(node as Statement, indent as string) as string:
+		written = Statement(node, indent + "\t")
+		return "${indent}\tpass\n" if string.IsNullOrEmpty(written)
+		return written
+
+	private static def Value(node as Expression) as string:
+	"""One expression, or a "# TODO" comment holding the C# it came from."""
+		return "null" if node is null or node.IsNull
+
+		literal = node as PrimitiveExpression
+		return Literal(literal) if literal is not null
+
+		named = node as IdentifierExpression
+		return named.Identifier if named is not null
+
+		member = node as MemberReferenceExpression
+		return "${Value(member.Target)}.${member.MemberName}" if member is not null
+
+		call = node as InvocationExpression
+		return "${Value(call.Target)}(${Arguments(call.Arguments)})" if call is not null
+
+		made = node as ObjectCreateExpression
+		return "${Decompiled.BooType(made.Type)}(${Arguments(made.Arguments)})" if made is not null
+
+		binary = node as BinaryOperatorExpression
+		if binary is not null:
+			operator = Operator(binary.Operator)
+			return Unwritten(node) if operator is null
+			return "${Value(binary.Left)} ${operator} ${Value(binary.Right)}"
+
+		unary = node as UnaryOperatorExpression
+		if unary is not null:
+			after = Suffix(unary.Operator)
+			return "${Value(unary.Expression)}${after}" if after is not null
+			operator = Prefix(unary.Operator)
+			return Unwritten(node) if operator is null
+			return "${operator}${Value(unary.Expression)}"
+
+		assigned = node as AssignmentExpression
+		if assigned is not null:
+			operator = Assignment(assigned.Operator)
+			return Unwritten(node) if operator is null
+			return "${Value(assigned.Left)} ${operator} ${Value(assigned.Right)}"
+
+		converted = node as CastExpression
+		return "cast(${Decompiled.BooType(converted.Type)}, ${Value(converted.Expression)})" if converted is not null
+
+		indexed = node as IndexerExpression
+		return "${Value(indexed.Target)}[${Arguments(indexed.Arguments)}]" if indexed is not null
+
+		wrapped = node as ParenthesizedExpression
+		return "(${Value(wrapped.Expression)})" if wrapped is not null
+
+		chosen = node as ConditionalExpression
+		if chosen is not null:
+			return "(${Value(chosen.TrueExpression)} if ${Value(chosen.Condition)} else ${Value(chosen.FalseExpression)})"
+
+		named_type = node as TypeReferenceExpression
+		return Decompiled.BooType(named_type.Type) if named_type is not null
+
+		return "self" if node isa ThisReferenceExpression
+		return "super" if node isa BaseReferenceExpression
+		return "null" if node isa NullReferenceExpression
+
+		return Unwritten(node)
+
+	private static def Literal(literal as PrimitiveExpression) as string:
+		value = literal.Value
+		return "null" if value is null
+		return ("true" if cast(bool, value) else "false") if value isa bool
+		return Quoted(value as string) if value isa string
+		return "char('${value}')" if value isa char
+		return value.ToString()
+
+	private static def Quoted(text as string) as string:
+	"""A Boo string literal, with quotes and backslashes escaped."""
+		quote = char('"').ToString()
+		slash = char('\\').ToString()
+		written = text.Replace(slash, slash + slash).Replace(quote, slash + quote)
+		return quote + written + quote
+
+	private static def Arguments(arguments as AstNodeCollection[of Expression]) as string:
+		written = System.Collections.Generic.List[of string]()
+		for argument in arguments:
+			written.Add(Value(argument))
+		return string.Join(", ", written.ToArray())
+
+	private static def Assignment(operator as AssignmentOperatorType) as string:
+		return "=" if operator == AssignmentOperatorType.Assign
+		return "+=" if operator == AssignmentOperatorType.Add
+		return "-=" if operator == AssignmentOperatorType.Subtract
+		return "*=" if operator == AssignmentOperatorType.Multiply
+		return "/=" if operator == AssignmentOperatorType.Divide
+		return "%=" if operator == AssignmentOperatorType.Modulus
+		return "<<=" if operator == AssignmentOperatorType.ShiftLeft
+		return ">>=" if operator == AssignmentOperatorType.ShiftRight
+		return "&=" if operator == AssignmentOperatorType.BitwiseAnd
+		return "|=" if operator == AssignmentOperatorType.BitwiseOr
+		return "^=" if operator == AssignmentOperatorType.ExclusiveOr
+		return null
+
+	private static def Operator(operator as BinaryOperatorType) as string:
+		return "and" if operator == BinaryOperatorType.ConditionalAnd
+		return "or" if operator == BinaryOperatorType.ConditionalOr
+		return "==" if operator == BinaryOperatorType.Equality
+		return "!=" if operator == BinaryOperatorType.InEquality
+		return "<" if operator == BinaryOperatorType.LessThan
+		return ">" if operator == BinaryOperatorType.GreaterThan
+		return "<=" if operator == BinaryOperatorType.LessThanOrEqual
+		return ">=" if operator == BinaryOperatorType.GreaterThanOrEqual
+		return "+" if operator == BinaryOperatorType.Add
+		return "-" if operator == BinaryOperatorType.Subtract
+		return "*" if operator == BinaryOperatorType.Multiply
+		return "/" if operator == BinaryOperatorType.Divide
+		return "%" if operator == BinaryOperatorType.Modulus
+		return "&" if operator == BinaryOperatorType.BitwiseAnd
+		return "|" if operator == BinaryOperatorType.BitwiseOr
+		return "^" if operator == BinaryOperatorType.ExclusiveOr
+		return "<<" if operator == BinaryOperatorType.ShiftLeft
+		return ">>" if operator == BinaryOperatorType.ShiftRight
+		return null
+
+	private static def Suffix(operator as UnaryOperatorType) as string:
+	"""Increment and decrement, which Boo writes the same as C#."""
+		return "++" if operator == UnaryOperatorType.PostIncrement or operator == UnaryOperatorType.Increment
+		return "--" if operator == UnaryOperatorType.PostDecrement or operator == UnaryOperatorType.Decrement
+		return null
+
+	private static def Prefix(operator as UnaryOperatorType) as string:
+		return "not " if operator == UnaryOperatorType.Not
+		return "-" if operator == UnaryOperatorType.Minus
+		return "" if operator == UnaryOperatorType.Plus
+		return "~" if operator == UnaryOperatorType.BitNot
+		return null
+
+	private static def Unwritten(node as AstNode, indent as string) as string:
+		return "${indent}${Unwritten(node)}\n"
+
+	private static def Unwritten(node as AstNode) as string:
+	"""A "# TODO" comment holding the C# that has no Boo equivalent."""
+		text = node.ToString().Replace("\r", " ").Replace("\n", " ").Trim()
+		text = text.Substring(0, 90) + "..." if text.Length > 90
+		return "# TODO: ${text}"

--- a/src/Boo.Lang.Decompiler/Boo.Lang.Decompiler.booproj
+++ b/src/Boo.Lang.Decompiler/Boo.Lang.Decompiler.booproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Boo.Lang.Decompiler</AssemblyName>
+    <RootNamespace>Boo.Lang.Decompiler</RootNamespace>
+    <Description>Writes what an assembly holds as Boo.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Boo.Lang/Boo.Lang.csproj" />
+    <ProjectReference Include="../booc/booc.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="../../Boo.targets" />
+
+</Project>

--- a/src/Boo.Lang.Decompiler/Decompiled.boo
+++ b/src/Boo.Lang.Decompiler/Decompiled.boo
@@ -1,0 +1,165 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace Boo.Lang.Decompiler
+
+import System
+import System.Text
+import ICSharpCode.Decompiler
+import ICSharpCode.Decompiler.CSharp
+import ICSharpCode.Decompiler.CSharp.Syntax
+import ICSharpCode.Decompiler.TypeSystem as Metadata
+
+class Decompiled:
+"""
+Converts a type from a compiled assembly to Boo.
+
+DecompileType returns a C# syntax tree rather than text, so the
+declarations can be walked and rewritten in another language.
+"""
+
+	static def Of(assembly as string, fullName as string) as string:
+		tree = TreeOf(assembly, fullName)
+		return null if tree is null
+
+		written = StringBuilder()
+		for child in tree.Children:
+			space = child as NamespaceDeclaration
+			continue if space is null
+			written.Append("namespace ").Append(space.Name).Append("\n")
+			for member in space.Members:
+				declared = member as TypeDeclaration
+				written.Append("\n").Append(TypeOf(declared, "")) if declared is not null
+		return null if written.Length == 0
+		return written.ToString()
+
+	private static def TreeOf(assembly as string, fullName as string) as SyntaxTree:
+		try:
+			decompiler = CSharpDecompiler(assembly, DecompilerSettings())
+			return decompiler.DecompileType(Metadata.FullTypeName(fullName))
+		except e as Exception:
+			# A caller gets null and decides what to say about it.
+			return null
+
+	private static def TypeOf(declared as TypeDeclaration, indent as string) as string:
+		written = StringBuilder()
+		written.Append(indent).Append(KindOf(declared)).Append(" ").Append(declared.Name)
+		written.Append(TypeParametersOf(declared)).Append(":\n")
+
+		body = StringBuilder()
+		for member in declared.Members:
+			line = MemberOf(member, indent + "\t")
+			body.Append("\n").Append(line) unless string.IsNullOrEmpty(line)
+
+		written.Append(("\n${indent}\tpass\n" if body.Length == 0 else body.ToString()))
+		return written.ToString()
+
+	private static def TypeParametersOf(declared as TypeDeclaration) as string:
+	"""The [of T] a generic type needs, so its members can refer to T."""
+		return "" if declared.TypeParameters.Count == 0
+		names = System.Collections.Generic.List[of string]()
+		for parameter as TypeParameterDeclaration in declared.TypeParameters:
+			names.Add(parameter.Name)
+		return "[of ${string.Join(', ', names.ToArray())}]"
+
+	private static def KindOf(declared as TypeDeclaration) as string:
+		return "interface" if declared.ClassType == ClassType.Interface
+		return "enum" if declared.ClassType == ClassType.Enum
+		return "struct" if declared.ClassType == ClassType.Struct
+		return "class"
+
+	private static def MemberOf(member as AstNode, indent as string) as string:
+		return null unless IsPublic(member)
+
+		nested = member as TypeDeclaration
+		return TypeOf(nested, indent) if nested is not null
+
+		made = member as ConstructorDeclaration
+		if made is not null:
+			return "${indent}def constructor(${ParametersOf(made.Parameters)}):\n${Bodies.Of(made.Body, indent + "\t")}"
+
+		method = member as MethodDeclaration
+		if method is not null:
+			signature = "${indent}${Modifier(method)}def ${method.Name}(${ParametersOf(method.Parameters)})"
+			return "${signature} as ${BooType(method.ReturnType)}:\n${Bodies.Of(method.Body, indent + "\t")}"
+
+		property = member as PropertyDeclaration
+		if property is not null:
+			return "${indent}${Modifier(property)}${property.Name} as ${BooType(property.ReturnType)}:\n${indent}\tget:\n${indent}\t\tpass\n"
+
+		field = member as FieldDeclaration
+		return FieldOf(field, indent) if field is not null
+
+		enumerated = member as EnumMemberDeclaration
+		return "${indent}${enumerated.Name}\n" if enumerated is not null
+
+		return null
+
+	private static def FieldOf(field as FieldDeclaration, indent as string) as string:
+	"""One line per field, whose names live on the declaration's variables."""
+		written = StringBuilder()
+		for variable as VariableInitializer in field.Variables:
+			written.Append(indent).Append(Modifier(field)).Append(variable.Name)
+			written.Append(" as ").Append(BooType(field.ReturnType)).Append("\n")
+		return written.ToString()
+
+	private static def IsPublic(member as AstNode) as bool:
+		declared = member as EntityDeclaration
+		return false if declared is null
+		return (declared.Modifiers & Modifiers.Public) == Modifiers.Public
+
+	private static def Modifier(declared as EntityDeclaration) as string:
+		return ("static " if (declared.Modifiers & Modifiers.Static) == Modifiers.Static else "")
+
+	private static def ParametersOf(parameters as AstNodeCollection[of ParameterDeclaration]) as string:
+		written = System.Collections.Generic.List[of string]()
+		for parameter in parameters:
+			written.Add("${parameter.Name} as ${BooType(parameter.Type)}")
+		return string.Join(", ", written.ToArray())
+
+	internal static def BooType(type as AstType) as string:
+	"""
+	A C# type name as Boo writes it.
+
+	The primitives are spelled the same; arrays and generics are not.
+	"""
+		return "object" if type is null or type.IsNull
+		return BooName(type.ToString())
+
+	private static def BooName(name as string) as string:
+		return "object" if string.IsNullOrEmpty(name)
+
+		if name.EndsWith("[]"):
+			return "(${BooName(name.Substring(0, name.Length - 2))})"
+
+		open = name.IndexOf(char('<'))
+		if open > 0 and name.EndsWith(">"):
+			inner = name.Substring(open + 1, name.Length - open - 2)
+			return "${name.Substring(0, open)}[of ${BooName(inner)}]"
+
+		return name.Replace("?", "")

--- a/src/Boo.Lang.Extensions/Boo.Lang.Extensions.booproj
+++ b/src/Boo.Lang.Extensions/Boo.Lang.Extensions.booproj
@@ -14,4 +14,13 @@
 
   <Import Project="../../Boo.targets" />
 
+  <!-- booc needs this beside Boo.Lang to resolve assert, using and the
+       attributes. It cannot reference the project it compiles, so the copy
+       goes here. -->
+  <Target Name="CopyToBooc" AfterTargets="Build" Condition="Exists('$(BoocDll)')">
+    <Copy SourceFiles="$(TargetPath)"
+          DestinationFolder="$([System.IO.Path]::GetDirectoryName($(BoocDll)))"
+          SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/src/Boo.Lang.Parser/BooErrorPatterns.cs
+++ b/src/Boo.Lang.Parser/BooErrorPatterns.cs
@@ -116,6 +116,16 @@ internal static class BooErrorPatterns
 				return string.Format(StringResources.BooParser_KeywordAsIdentifier, keyword);
 		}
 
+		if (pattern == null)
+		{
+			// Naming the token says nothing in a language where the layout is
+			// the syntax. What went wrong is the indentation, so say that.
+			if (offendingSymbol.Type == BooLexer.INDENT)
+				return StringResources.BooParser_UnexpectedIndent;
+			if (offendingSymbol.Type == BooLexer.DEDENT)
+				return StringResources.BooParser_UnexpectedDedent;
+		}
+
 		return pattern == null ? null : pattern.Message;
 	}
 

--- a/src/Boo.Lang.Parser/BooParser.g4.cs
+++ b/src/Boo.Lang.Parser/BooParser.g4.cs
@@ -72,6 +72,8 @@ partial class BooParser
 		}
 
 		var stream = new AntlrInputStream(reader);
+		// Without this a token reports <unknown> and its error lands on no file.
+		stream.name = readerName;
 		BooParser.StartContext tree;
 
 		try

--- a/src/Boo.Lang.Parser/BooParsingStep.cs
+++ b/src/Boo.Lang.Parser/BooParsingStep.cs
@@ -142,6 +142,13 @@ public class BooParsingStep : ICompilerStep
 		}
 		_lastErrorLine = line;
 
+		// An indentation token stands at the end of the line it closes, which
+		// points past the text. What is wrong is the layout, so say where it
+		// starts.
+		if (offendingSymbol != null
+			&& (offendingSymbol.Type == BooLexer.INDENT || offendingSymbol.Type == BooLexer.DEDENT))
+			charPositionInLine = 1;
+
 		var location = new LexicalInfo(filename, line, charPositionInLine);
 		var friendly = BooErrorPatterns.Match(recognizer, offendingSymbol, e);
 		if (friendly != null)

--- a/src/Boo.Lang.Parser/BooParsingStep.cs
+++ b/src/Boo.Lang.Parser/BooParsingStep.cs
@@ -107,6 +107,8 @@ public class BooParsingStep : ICompilerStep
 	{
 		var settings = My<Boo.Lang.Parser.ParserSettings>.Instance;
 		var stream = new AntlrInputStream(reader);
+		// Without this a token reports <unknown> and its error lands on no file.
+		stream.name = inputName;
 		BooParser.StartContext tree;
 
 		// SLL first, as BooParser.ParseModule does. It reports nothing, because it
@@ -142,9 +144,8 @@ public class BooParsingStep : ICompilerStep
 		}
 		_lastErrorLine = line;
 
-		// An indentation token stands at the end of the line it closes, which
-		// points past the text. What is wrong is the layout, so say where it
-		// starts.
+		// An indentation token sits past the end of the line it closes, so
+		// point at the start of the line instead.
 		if (offendingSymbol != null
 			&& (offendingSymbol.Type == BooLexer.INDENT || offendingSymbol.Type == BooLexer.DEDENT))
 			charPositionInLine = 1;

--- a/src/Boo.Lang.Parser/Util/IndentTokenStreamFilter.cs
+++ b/src/Boo.Lang.Parser/Util/IndentTokenStreamFilter.cs
@@ -113,6 +113,12 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 	/// </summary>
 	bool _dedented;
 
+	/// The line each open indent level was opened on.
+	Stack<int> _indentLines = new Stack<int>();
+
+	/// Depth of the quasi quotations in hand, which close on their own level.
+	int _quoted;
+
 	public IndentTokenStreamFilter(ITokenSource source, int wsType, int newlineTokenType, int indentType, int dedentType, int eosType, int endType, int idType)
 	{
 		if (null == source)
@@ -190,6 +196,7 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 
 			break;
 		}
+
 		return token;
 	}
 	
@@ -234,17 +241,28 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 			{
 				EnqueueIndent(token);
 				_indentStack.Push(lastLine.Length);
+				_indentLines.Push(token.Line);
 			}
 			else if (lastLine.Length < CurrentIndentLevel)
 			{
 				EnqueueEOS(token);
 				_dedented = true;
+				var opened = token.Line;
 				do 
 				{
 					EnqueueDedent();
 					_indentStack.Pop();
+					if (_indentLines.Count > 0)
+						opened = _indentLines.Pop();
 				}
 				while (lastLine.Length < CurrentIndentLevel);
+
+				// Landing between two levels means the block that just closed was
+				// opened further in than the rest, so name that line, not this one.
+				if (lastLine.Length != CurrentIndentLevel && _quoted == 0)
+					throw Boo.Lang.Compiler.CompilerErrorFactory.GenericParserError(
+						new Boo.Lang.Compiler.Ast.LexicalInfo(token.InputStream.SourceName, opened, 1),
+						new Exception(Boo.Lang.Resources.StringResources.BooParser_InconsistentIndentation));
 			}
 			else
 			{
@@ -306,7 +324,11 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 		IToken token = BufferUntilNextNonWhiteSpaceToken();
 		ReleaseHeldEnd(token);
 		_dedented = false;
-		FlushBuffer(token);			
+		FlushBuffer(token);
+		if (token.Type == Boo.Lang.Parser.BooLexer.QQ_BEGIN)
+			_quoted++;
+		else if (token.Type == Boo.Lang.Parser.BooLexer.QQ_END && _quoted > 0)
+			_quoted--;
 		CheckForEOF(token);
 		ProcessNextNonWhiteSpaceToken(token);
 	}

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -283,6 +283,7 @@ namespace Boo.Lang.Resources
 		public const string BooParser_SeparateExpressionsWithCommas = "Expressions must be separated by commas";
 		public const string BooParser_MixedIndentation = "Mixed indentation, expected the use of {0}";
 		public const string BooParser_UnexpectedIndent = "Unexpected indentation, nothing here opens a block";
+		public const string BooParser_InconsistentIndentation = "Inconsistent indentation, this line does not line up with the rest of its block";
 		public const string BooParser_UnexpectedDedent = "Indentation does not line up with any block that is open";
 		public const string BooParser_DuplicateAccessor = "A property can only state one {0}";
 		public const string BooParser_KeywordAsIdentifier = "Illegal use of keyword '{0}' as identifier";

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -282,6 +282,8 @@ namespace Boo.Lang.Resources
 		public const string BooParser_UnbalancedOpeningParen = "Unbalanced expression, opening paren not found";
 		public const string BooParser_SeparateExpressionsWithCommas = "Expressions must be separated by commas";
 		public const string BooParser_MixedIndentation = "Mixed indentation, expected the use of {0}";
+		public const string BooParser_UnexpectedIndent = "Unexpected indentation, nothing here opens a block";
+		public const string BooParser_UnexpectedDedent = "Indentation does not line up with any block that is open";
 		public const string BooParser_DuplicateAccessor = "A property can only state one {0}";
 		public const string BooParser_KeywordAsIdentifier = "Illegal use of keyword '{0}' as identifier";
 		public const string BooParser_DuplicateDocstring = "A docstring can only be written once, either above the body or within it";

--- a/src/booc/CommandLineParser.cs
+++ b/src/booc/CommandLineParser.cs
@@ -59,6 +59,8 @@ namespace booc
 		readonly List<string> _references = new List<string>();
 		readonly List<string> _packages = new List<string>();
 		bool _noConfig;
+
+		bool _noExtensions;
 		string _pipelineName;
 		bool _debugSteps;
 
@@ -77,7 +79,7 @@ namespace booc
 			_options.LibPaths.Extend(tempLibPaths);
 
 			if (_options.StdLib)
-				_options.LoadDefaultReferences();
+				_options.LoadDefaultReferences(!_noExtensions);
 			else if (!_noConfig)
 				_references.Insert(0, "mscorlib");
 
@@ -226,6 +228,8 @@ namespace booc
 								noLogo = true;
 							else if (arg == "-noconfig")
 								_noConfig = true;
+							else if (arg == "-noextensions")
+								_noExtensions = true;
 							else if (arg == "-nostdlib")
 								_options.StdLib = false;
 							else if (arg == "-nowarn")
@@ -574,6 +578,7 @@ namespace booc
 					" -keyfile:FILE        The strongname key file used to strongname the assembly\n" +
 					" -lib:DIRS            Adds the comma-separated DIRS to the assembly search path\n" +
 					" -noconfig            Does not load the standard configuration\n" +
+					" -noextensions        Does not reference Boo.Lang.Extensions\n" +
 					" -nologo              Does not display the compiler logo\n" +
 					" -nostdlib            Does not reference any of the default libraries\n" +
 					" -nowarn[:W1,Wn]      Suppress all or a list of compiler warnings\n" +

--- a/tests/Boo.Lang.Decompiler.Tests/Boo.Lang.Decompiler.Tests.booproj
+++ b/tests/Boo.Lang.Decompiler.Tests/Boo.Lang.Decompiler.Tests.booproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>Boo.Lang.Decompiler.Tests</AssemblyName>
+    <RootNamespace>Boo.Lang.Decompiler.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Boo.Lang/Boo.Lang.csproj" />
+    <ProjectReference Include="../../src/Boo.Lang.Parser/Boo.Lang.Parser.csproj" />
+    <ProjectReference Include="../../src/Boo.Lang.Extensions/Boo.Lang.Extensions.booproj" />
+    <ProjectReference Include="../../src/Boo.Lang.Decompiler/Boo.Lang.Decompiler.booproj" />
+    <ProjectReference Include="../../src/booc/booc.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="../../Boo.targets" />
+
+</Project>

--- a/tests/Boo.Lang.Decompiler.Tests/DecompiledTestFixture.boo
+++ b/tests/Boo.Lang.Decompiler.Tests/DecompiledTestFixture.boo
@@ -1,0 +1,82 @@
+namespace Boo.Lang.Decompiler.Tests
+
+import System
+import System.IO
+import NUnit.Framework(TestFixtureAttribute, TestAttribute, Assert)
+import Boo.Lang.Parser
+import Boo.Lang.Decompiler
+
+[TestFixture]
+class DecompiledTestFixture:
+"""Reading a type out of an assembly and writing it as Boo."""
+
+	private static final CoreLib = typeof(System.IO.Path).Assembly.Location
+
+	private def Written(fullName as string) as string:
+		text = Decompiled.Of(CoreLib, fullName)
+		assert text is not null, "nothing written for ${fullName}"
+		return text
+
+	[Test]
+	def WritesTheNamespaceAndTheType():
+		written = Written("System.IO.Path")
+		assert written.StartsWith("namespace System.IO\n"), written
+		assert "class Path:" in written, written
+
+	[Test]
+	def WritesAMemberSignature():
+		assert "static def GetTempPath() as string:" in Written("System.IO.Path")
+
+	[Test]
+	def WritesAnArrayAndAGenericTheBooWay():
+		assert "as (char)" in Written("System.IO.Path")
+		assert "class List[of T]:" in Written("System.Collections.Generic.List`1")
+
+	[Test]
+	def WritesABodyRatherThanPass():
+		written = Written("System.IO.Path")
+		assert "if path == null:" in written, "no converted statement"
+		assert "while num2 >= 0:" in written, "no converted loop"
+
+	[Test]
+	def NamesWhatItCannotWrite():
+		assert "# TODO:" in Written("System.IO.Path")
+
+	[Test]
+	def SaysNothingForATypeTheAssemblyLacks():
+		assert Decompiled.Of(CoreLib, "No.Such.Type") is null
+
+	private def Across(*names as (string)) as string:
+		written = ""
+		for name in names:
+			written += Written(name)
+		return written
+
+	[Test]
+	def WritesTheStatementsItConverts():
+	"""
+	Read off a handful of types rather than one method, so a change in
+	what the framework ships does not fail the wrong thing.
+	"""
+		written = Across("System.IO.Path", "System.Convert", "System.TimeSpan")
+		assert "elif " in written, "no switch converted"
+		assert "try:" in written, "no try converted"
+		assert "except " in written, "no catch converted"
+		assert "for " in written, "no foreach converted"
+
+	[Test]
+	def WritesTheExpressionsItConverts():
+		written = Across("System.IO.Path", "System.Convert", "System.Version")
+		assert "+=" in written, "no compound assignment"
+		assert "cast(" in written, "no cast"
+		assert "raise " in written, "no throw"
+
+	[Test]
+	def WritesBooTheParserAccepts():
+		for name in ("System.IO.Path", "System.Collections.Generic.List`1", "System.Version"):
+			path = Path.Combine(Path.GetTempPath(), "dec-" + Guid.NewGuid().ToString("N") + ".boo")
+			File.WriteAllText(path, Written(name))
+			try:
+				BooParser.ParseFile(path)
+			ensure:
+				File.Delete(path)

--- a/tests/BooCompiler.Tests/IndentationErrorTest.boo
+++ b/tests/BooCompiler.Tests/IndentationErrorTest.boo
@@ -1,0 +1,66 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace BooCompiler.Tests
+
+import NUnit.Framework
+
+[TestFixture]
+class IndentationErrorTest:
+"""
+What the parser says when the layout is wrong.
+
+Naming the token says nothing in a language where the layout is the syntax.
+"""
+
+	private def FirstError(code as string) as string:
+		compiler = Boo.Lang.Compiler.BooCompiler()
+		compiler.Parameters.Input.Add(Boo.Lang.Compiler.IO.StringInput("testcase", code))
+		compiler.Parameters.Pipeline = Boo.Lang.Compiler.Pipelines.Parse()
+		errors = compiler.Run().Errors
+		Assert.IsTrue(errors.Count >= 1, "nothing was reported")
+		return errors[0].Message
+
+	[Test]
+	def SaysWhatIsWrongWhenABodyIsIndentedTooFar():
+		# The docstring is a level further in than the class body it opens.
+		message = FirstError("class Greeter:\n\t\t\"\"\"over indented\"\"\"\n")
+		Assert.AreEqual("Indentation does not line up with any block that is open.", message)
+
+	[Test]
+	def StillSaysABlockMustBeIndented():
+		Assert.AreEqual("Block must be indented.", FirstError("foo:\nclass"))
+
+	[Test]
+	def PointsAtTheStartOfTheLineNotPastItsEnd():
+		compiler = Boo.Lang.Compiler.BooCompiler()
+		compiler.Parameters.Input.Add(Boo.Lang.Compiler.IO.StringInput("testcase", "class Greeter:\n\t\t\"\"\"over indented\"\"\"\n"))
+		compiler.Parameters.Pipeline = Boo.Lang.Compiler.Pipelines.Parse()
+		error = compiler.Run().Errors[0]
+		Assert.AreEqual(2, error.LexicalInfo.Line)
+		Assert.AreEqual(1, error.LexicalInfo.Column)

--- a/tests/BooCompiler.Tests/IndentationErrorTest.boo
+++ b/tests/BooCompiler.Tests/IndentationErrorTest.boo
@@ -89,3 +89,18 @@ Naming the token says nothing in a language where the layout is the syntax.
 	def NamesTheFileTheIndentationIsIn():
 	"""An error on no file is one the editor cannot put anywhere."""
 		Assert.AreEqual("testcase", Errors("def f():\n\tx = 1\n    y = 2\n")[0].LexicalInfo.FileName)
+
+	[Test]
+	def NamesTheLineIndentedFurtherThanItsBlock():
+	"""
+	The line that opened the block is the one to fix, not the line that
+	closed it by lining up with the rest.
+	"""
+		errors = Errors("class C:\n\tdef f(a as int) as int:\n\t\t\tns = a\n\t\treturn ns\n")
+		Assert.AreEqual("Inconsistent indentation, this line does not line up with the rest of its block.", errors[0].Message)
+		Assert.AreEqual(3, errors[0].LexicalInfo.Line)
+
+	[Test]
+	def AcceptsAQuotationThatClosesOnItsOwnLevel():
+	"""A quasi quotation ends where it likes, and the compiler's own macros do."""
+		Assert.AreEqual(0, Errors("def f():\n\treturn [|\n\t\t\tclass C:\n\t\t\t\tpass\n\t\t|]\n").Count)

--- a/tests/BooCompiler.Tests/IndentationErrorTest.boo
+++ b/tests/BooCompiler.Tests/IndentationErrorTest.boo
@@ -64,3 +64,28 @@ Naming the token says nothing in a language where the layout is the syntax.
 		error = compiler.Run().Errors[0]
 		Assert.AreEqual(2, error.LexicalInfo.Line)
 		Assert.AreEqual(1, error.LexicalInfo.Column)
+
+	private def Errors(code as string):
+		compiler = Boo.Lang.Compiler.BooCompiler()
+		compiler.Parameters.Input.Add(Boo.Lang.Compiler.IO.StringInput("testcase", code))
+		compiler.Parameters.Pipeline = Boo.Lang.Compiler.Pipelines.Parse()
+		return compiler.Run().Errors
+
+	[Test]
+	def AcceptsAFileIndentedThroughout():
+		Assert.AreEqual(0, Errors("def f():\n\tx = 1\n\ty = 2\n").Count, "tabs")
+		Assert.AreEqual(0, Errors("def f():\n    x = 1\n    y = 2\n").Count, "spaces")
+
+	[Test]
+	def RefusesTabsAndSpacesOnTheSameLine():
+		Assert.AreEqual("Mixed indentation, expected the use of tabs.", Errors("def f():\n\t  x = 1\n")[0].Message)
+
+	[Test]
+	def RefusesOneKindOfIndentAfterAnother():
+		Assert.AreEqual("Mixed indentation, expected the use of tabs.", Errors("def f():\n\tx = 1\n    y = 2\n")[0].Message)
+		Assert.AreEqual("Mixed indentation, expected the use of spaces.", Errors("def f():\n    x = 1\n\ty = 2\n")[0].Message)
+
+	[Test]
+	def NamesTheFileTheIndentationIsIn():
+	"""An error on no file is one the editor cannot put anywhere."""
+		Assert.AreEqual("testcase", Errors("def f():\n\tx = 1\n    y = 2\n")[0].LexicalInfo.FileName)

--- a/tests/BooCompiler.Tests/LoadAssemblyTest.boo
+++ b/tests/BooCompiler.Tests/LoadAssemblyTest.boo
@@ -1,0 +1,61 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace BooCompiler.Tests
+
+import System
+import System.IO
+import Boo.Lang.Compiler
+import NUnit.Framework
+
+[TestFixture]
+class LoadAssemblyTest:
+"""Loading a reference that will not load."""
+
+	directory as string
+
+	[SetUp]
+	def Setup():
+		directory = Path.Combine(Path.GetTempPath(), "boo-lib-" + Guid.NewGuid().ToString("N"))
+		Directory.CreateDirectory(directory)
+
+	[TearDown]
+	def Teardown():
+		Directory.Delete(directory, true) if Directory.Exists(directory)
+
+	[Test]
+	def ReturnsNullForAnUnloadableAssemblyInALibPath():
+	"""
+	A reference that will not load is an answer, not a reason to abandon the
+	compilation. boolsp analyses against whatever a project last built, and
+	a half written output would otherwise take the whole analysis down.
+	"""
+		File.WriteAllText(Path.Combine(directory, "NotReally.dll"), "not an assembly")
+		parameters = CompilerParameters(false)
+		parameters.LibPaths.Add(directory)
+		Assert.IsNull(parameters.LoadAssembly("NotReally.dll", false))

--- a/tests/booc.Tests/CommandLineParserTest.boo
+++ b/tests/booc.Tests/CommandLineParserTest.boo
@@ -50,6 +50,23 @@ class CommandLineParserTest:
 			m = Methods.Of[of object](MethodWithCustomTypeInferenceRule)
 			Assert.AreEqual("custom", My[of TypeInferenceRuleProvider].Instance.TypeInferenceRuleFor(m))
 
+	private def ReferencesExtensions(args as (string)) as bool:
+		# False, as booc does it: the parser loads the defaults itself.
+		parameters = CompilerParameters(false)
+		booc.CommandLineParser.ParseInto(parameters, *args)
+		for reference in parameters.References:
+			return true if reference.Name == "Boo.Lang.Extensions"
+		return false
+
+	[Test]
+	def ExtensionsAreReferencedByDefault():
+		Assert.IsTrue(ReferencesExtensions((of string: "foo.boo")))
+
+	[Test]
+	def NoExtensionsLeavesThemOut():
+	"""Compiling Boo.Lang.Extensions needs this: the loaded copy collides."""
+		Assert.IsFalse(ReferencesExtensions(("-noextensions", "foo.boo")))
+
 	[CommandLineParserTest.CustomAttribute]
 	public static def MethodWithCustomTypeInferenceRule() as object:
 		return null


### PR DESCRIPTION
This PR contains things not-directly related to the LSP implementation, but that I found while implementing it. It's mainly:

- A new `Boo.Lang.Decompiler` project so that Go To Definition can decompile to Boo.
  That will be an option, but C# will be the higher fidelity decompilation for now
- `booc` never shipped `Boo.Lang.Extensions` beside itself, so a plain
  `booc script.boo` could not resolve `assert`, `using` or `macro` while `booi`
  ran the same file. `-noextensions` lets booc still compile the Extensions
  assembly itself.
- A lib path scan threw past an unloadable file despite being asked not to,
  taking a whole compilation down over one bad assembly.
- Three parser commits. An unexpected indent or dedent said
  `Unexpected token: <DEDENT>` at a column past the end of the line. The error
  named no file, so an editor filtering diagnostics by file showed nothing at
  all. An over indented block reported on the line that closed it rather than
  the line that opened it.

## Notes for review

- Decompiler output is a string, not a Boo AST. The AST has no free standing comment,
  so the `# TODO` annotations would be dropped by a round trip through it. An AST is
  on the roadmap, but rather than try to make the decompiler perfect, this was a good
  enough compromise
- `UsingStatement` handling is present but does not fire on the framework: the
  decompiler lowers `using` to try/finally. Again, a compromise to ship software,
  not the final desired end state.
- Tests read several types rather than one method, so a change in what the
  framework ships does not fail the wrong assertion. The parser round trip is
  the version independent check.
- I ensured every commit builds on its own.
