### PR TITLE
fix(Parser): ignore an optional end outside wsa mode

### DIFF
--- a/src/Boo.Lang.Parser/Util/IndentTokenStreamFilter.cs
+++ b/src/Boo.Lang.Parser/Util/IndentTokenStreamFilter.cs
@@ -103,6 +103,16 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 
 	System.Text.StringBuilder _buffer = new System.Text.StringBuilder();
 
+	/// <summary>
+	/// An `end` to drop, held until the next token tells it from a name.
+	/// </summary>
+	IToken _heldEnd;
+
+	/// <summary>
+	/// Whether the layout before the token in hand closed a block.
+	/// </summary>
+	bool _dedented;
+
 	public IndentTokenStreamFilter(ITokenSource source, int wsType, int newlineTokenType, int indentType, int dedentType, int eosType, int endType, int idType)
 	{
 		if (null == source)
@@ -228,6 +238,7 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 			else if (lastLine.Length < CurrentIndentLevel)
 			{
 				EnqueueEOS(token);
+				_dedented = true;
 				do 
 				{
 					EnqueueDedent();
@@ -257,7 +268,35 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 	void ProcessNextNonWhiteSpaceToken(IToken token)
 	{
 		_lastNonWsToken = token;
+		// A lone `end` is dropped, so hold it until the next token tells it
+		// from a name being assigned or read.
+		if (token.Type == _endTokenType && _dedented)
+		{
+			_heldEnd = token;
+			return;
+		}
 		Enqueue(token);
+	}
+
+	/// <summary>
+	/// Settle the `end` in hand now that the next token is known: alone on its
+	/// line it is dropped, anywhere else it is a name.
+	/// </summary>
+	void ReleaseHeldEnd(IToken token)
+	{
+		if (null == _heldEnd) return;
+
+		IToken held = _heldEnd;
+		_heldEnd = null;
+		if (token.Type == TokenConstants.EOF || BufferHasNewLine()) return;
+
+		((IWritableToken)held).Type = _idTokenType;
+		Enqueue(held);
+	}
+
+	bool BufferHasNewLine()
+	{
+		return _buffer.Length > 0 && _buffer.ToString().IndexOfAny(NewLineCharArray) >= 0;
 	}
 	
 	void ProcessNextTokens()
@@ -265,6 +304,8 @@ public class IndentTokenStreamFilter : Antlr4.Runtime.ITokenSource
 		ResetBuffer();
 			
 		IToken token = BufferUntilNextNonWhiteSpaceToken();
+		ReleaseHeldEnd(token);
+		_dedented = false;
 		FlushBuffer(token);			
 		CheckForEOF(token);
 		ProcessNextNonWhiteSpaceToken(token);

--- a/tests/BooCompiler.Tests/EndKeywordTest.boo
+++ b/tests/BooCompiler.Tests/EndKeywordTest.boo
@@ -1,0 +1,79 @@
+namespace BooCompiler.Tests
+
+import Boo.Lang.Compiler
+import Boo.Lang.Compiler.IO
+import Boo.Lang.Compiler.Pipelines
+import NUnit.Framework
+
+[TestFixture]
+class EndKeywordTest:
+"""
+`end` is optional outside whitespace agnostic mode, and closes nothing.
+
+The layout still decides where a block ends, so a lone `end` is dropped and
+has to line up the way any other line would. Anywhere a name could stand
+instead, a name is what it is.
+
+The sources are written flush left: indentation is the syntax under test, and
+escaping it reads as nothing at all.
+"""
+
+	private def BoundErrors(code as string):
+		compiler = BooCompiler()
+		compiler.Parameters.Input.Add(StringInput("testcase", code))
+		compiler.Parameters.Pipeline = ResolveExpressions(BreakOnErrors: false)
+		return compiler.Run().Errors
+
+	[Test]
+	def DropsALoneEndAfterABlockDedents():
+		Assert.AreEqual(0, BoundErrors("""
+def f() as int:
+	return 1
+end
+
+print f()
+""").Count)
+
+	[Test]
+	def DropsALoneEndAfterEachNestedBlock():
+		Assert.AreEqual(0, BoundErrors("""
+class C:
+	def g() as int:
+		return 1
+	end
+end
+
+print C().g()
+""").Count)
+
+	[Test]
+	def KeepsEndAsAnIdentifier():
+		Assert.AreEqual(0, BoundErrors("""
+def f() as int:
+	end = 1
+	return end
+
+print f()
+""").Count)
+
+	[Test]
+	def KeepsEndAsAnIdentifierOnALineThatDedents():
+	"""A dedent alone is not enough to drop it: nothing may follow it."""
+		Assert.AreEqual(0, BoundErrors("""
+def f() as int:
+	if 1 > 0:
+		pass
+	end = 1
+	return end
+
+print f()
+""").Count)
+
+	[Test]
+	def RefusesALoneEndThatDedentsNothing():
+	"""Lining up with the block it sits in leaves it a name, and an unknown one."""
+		Assert.AreEqual(1, BoundErrors("""
+def f():
+	pass
+	end
+""").Count)


### PR DESCRIPTION
Determining between WSA mode and non-WSA mode created a lot of unnecessary complexity in the Boo LSP as I was developing it, and I realized - why does the default mode care if an `end` is used at all? As long as the complete line statement is dedent + end, and not `end = 12`, we can safely ignore the `end`, and that lets us treat any boo file as the same - WSA mode has non-optional `end` terminations and can indent in crazy ways, and normal mode enforces indent blocks with or without the `end`. This PR allows `end` to exist in non-WSA mode. It's not a style we'd encourage, but standalone boo files without a project that are intended to be WSA files can be handled by an ad-hoc LSP compilation without issue.

This simple PR does the following:
- IndentTokenStreamFilter rewrote every END token to an identifier, so a lone end parsed as an expression naming nothing.
- Drop a lone end that follows a dedent; the layout has already closed the block, so it marks the close and nothing more.
- Hold it until the next token, which keeps end usable as a name.