### PR TITLE
Feat: ref structs

### DIFF
--- a/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
+++ b/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
@@ -311,6 +311,35 @@ namespace Boo.Lang.Compiler
 			return Instantiate("BCE0183", node, expression);
 		}
 		
+		/// <summary>
+		/// For a byreflike value asked to reach a reference type, which it can
+		/// only do by being boxed.
+		/// </summary>
+		public static CompilerError CannotBoxByRefLikeType(Node node, IType actualType, IType expectedType)
+		{
+			return Instantiate("BCE0190", node, actualType, expectedType);
+		}
+
+		public static CompilerError ByRefLikeFieldType(Node node, IType actualType, IType declaringType)
+		{
+			return Instantiate("BCE0191", node, actualType, declaringType);
+		}
+
+		public static CompilerError ByRefLikeTypeCaptured(Node node, IType actualType)
+		{
+			return Instantiate("BCE0192", node, actualType);
+		}
+
+		public static CompilerError ByRefLikeArrayElementType(Node node, IType actualType)
+		{
+			return Instantiate("BCE0193", node, actualType);
+		}
+
+		public static CompilerError ByRefLikeGenericArgument(Node node, IType actualType)
+		{
+			return Instantiate("BCE0194", node, actualType);
+		}
+
 		public static CompilerError LValueExpected(Node node)
 		{
 			return Instantiate("BCE0049", node, StripSurroundingParens(node.ToCodeString()));

--- a/src/Boo.Lang.Compiler/Pipelines/Compile.cs
+++ b/src/Boo.Lang.Compiler/Pipelines/Compile.cs
@@ -68,6 +68,8 @@ namespace Boo.Lang.Compiler.Pipelines
             Add(new DetectNotImplementedFeatureUsage());
 
 			Add(new ExpandVarArgsMethodInvocations());
+
+			Add(new CheckByRefLikeUsage());
 			
 			Add(new InjectCallableConversions());
 			Add(new CallableTypeElision());

--- a/src/Boo.Lang.Compiler/Steps/CheckAttributesUsage.cs
+++ b/src/Boo.Lang.Compiler/Steps/CheckAttributesUsage.cs
@@ -134,9 +134,21 @@ namespace Boo.Lang.Compiler.Steps
 
 			AttributeTargets target;
 			if (NodeUsageTargets().TryGetValue(node.ParentNode.GetType(), out target))
+			{
+				// BindTypeDefinitions rewrites every struct into a class over
+				// ValueType, so a struct arrives here looking like a class.
+				if (target == AttributeTargets.Class && IsValueTypeDefinition(node.ParentNode))
+					return AttributeTargets.Struct;
 				return target;
+			}
 
 			return null;
+		}
+
+		private static bool IsValueTypeDefinition(Node node)
+		{
+			var type = ((TypeDefinition)node).Entity as IType;
+			return type != null && type.IsValueType;
 		}
 
 		private static bool IsValid(AttributeTargets target, AttributeTargets validAttributeTargets)

--- a/src/Boo.Lang.Compiler/Steps/CheckByRefLikeUsage.cs
+++ b/src/Boo.Lang.Compiler/Steps/CheckByRefLikeUsage.cs
@@ -42,9 +42,14 @@ namespace Boo.Lang.Compiler.Steps
 		// One array type shows up at several nodes on its way through a method:
 		// the literal that mints it, the local it lands in, the parameter it is
 		// passed as. They are all the same mistake, so only the first is worth
-		// reporting.
+		// reporting. Cleared per method; a field is reported once per type.
 		private readonly List<IType> _reportedArrayTypes = new List<IType>();
 
+		/// <summary>
+		/// Nothing to say about a compilation that is already broken: the
+		/// earlier error is the one worth reading, and the boxing it rejected
+		/// has been reported by the type checker already.
+		/// </summary>
 		public override void Run()
 		{
 			if (Errors.Count > 0)
@@ -109,6 +114,10 @@ namespace Boo.Lang.Compiler.Steps
 				CheckForByRefLikeArray(node, local.Type);
 		}
 
+		/// <summary>
+		/// The parameter's own type covers what its type reference would say,
+		/// so the children are left unvisited rather than reported twice.
+		/// </summary>
 		public override void OnParameterDeclaration(ParameterDeclaration node)
 		{
 			var parameter = node.Entity as IParameter;

--- a/src/Boo.Lang.Compiler/Steps/CheckByRefLikeUsage.cs
+++ b/src/Boo.Lang.Compiler/Steps/CheckByRefLikeUsage.cs
@@ -1,0 +1,247 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+using System.Collections.Generic;
+using Boo.Lang.Compiler.Ast;
+using Boo.Lang.Compiler.TypeSystem;
+
+namespace Boo.Lang.Compiler.Steps
+{
+	/// <summary>
+	/// Reports the places where a byreflike value would reach the heap.
+	/// Runs after closures and generators are expanded so the fields they
+	/// hoist locals into are visible here.
+	/// </summary>
+	public class CheckByRefLikeUsage : AbstractFastVisitorCompilerStep
+	{
+		// One array type shows up at several nodes on its way through a method:
+		// the literal that mints it, the local it lands in, the parameter it is
+		// passed as. They are all the same mistake, so only the first is worth
+		// reporting.
+		private readonly List<IType> _reportedArrayTypes = new List<IType>();
+
+		public override void Run()
+		{
+			if (Errors.Count > 0)
+				return;
+			base.Run();
+		}
+
+		public override void OnMethod(Method node)
+		{
+			_reportedArrayTypes.Clear();
+			base.OnMethod(node);
+		}
+
+		public override void OnField(Field node)
+		{
+			var field = node.Entity as IField;
+			if (field == null)
+				return;
+
+			if (TypeSystemServices.IsByRefLike(field.Type) && !IsInstanceFieldOfByRefLikeType(field))
+			{
+				// A closure or a generator hoists the locals it needs into a
+				// synthetic class, which is a heap allocation like any other.
+				if (node.DeclaringType != null && node.DeclaringType.IsSynthetic)
+					Errors.Add(CompilerErrorFactory.ByRefLikeTypeCaptured(node, field.Type));
+				else
+					Errors.Add(CompilerErrorFactory.ByRefLikeFieldType(node, field.Type, field.DeclaringType));
+				return;
+			}
+
+			CheckForByRefLikeArray(node, field.Type);
+		}
+
+		/// <summary>
+		/// A byreflike struct may hold another one, since it stays on the stack
+		/// with its owner. A static field does not, wherever it is declared.
+		/// </summary>
+		private static bool IsInstanceFieldOfByRefLikeType(IField field)
+		{
+			return !field.IsStatic && TypeSystemServices.IsByRefLike(field.DeclaringType);
+		}
+
+		/// <summary>
+		/// Every array type the source spells out, wherever it appears: a field,
+		/// a parameter, a local, a return type, the target of a cast.
+		/// </summary>
+		public override void OnArrayTypeReference(ArrayTypeReference node)
+		{
+			base.OnArrayTypeReference(node);
+			CheckForByRefLikeArray(node, node.Entity as IType);
+		}
+
+		/// <summary>
+		/// A declaration loses its type reference once the local is created, so
+		/// the local itself is where a declared array type is still readable.
+		/// </summary>
+		public override void OnLocal(Local node)
+		{
+			base.OnLocal(node);
+			var local = node.Entity as ILocalEntity;
+			if (local != null)
+				CheckForByRefLikeArray(node, local.Type);
+		}
+
+		public override void OnParameterDeclaration(ParameterDeclaration node)
+		{
+			var parameter = node.Entity as IParameter;
+			if (parameter != null)
+				CheckForByRefLikeArray(node, parameter.Type);
+		}
+
+		public override void OnBinaryExpression(BinaryExpression node)
+		{
+			base.OnBinaryExpression(node);
+
+			// Assignment carries a value into the slot the left hand side names,
+			// and a duck slot is an object slot like any other. A type test asks
+			// the same of its left hand side, against object.
+			if (BinaryOperatorType.Assign == node.Operator)
+				CheckForBoxing(node.Right, node.Left.ExpressionType, node.Right.ExpressionType);
+			else if (BinaryOperatorType.TypeTest == node.Operator)
+				CheckForBoxing(node, TypeSystemServices.ObjectType, node.Left.ExpressionType);
+		}
+
+		public override void OnArrayLiteralExpression(ArrayLiteralExpression node)
+		{
+			base.OnArrayLiteralExpression(node);
+
+			var arrayType = node.ExpressionType as IArrayType;
+			if (arrayType == null)
+				return;
+
+			foreach (var item in node.Items)
+				CheckForBoxing(item, arrayType.ElementType, item.ExpressionType);
+		}
+
+		/// <summary>
+		/// Naming a reference type to cast to does not make the value reach it
+		/// any differently. The using macro casts to IDisposable this way.
+		/// </summary>
+		public override void OnCastExpression(CastExpression node)
+		{
+			base.OnCastExpression(node);
+			CheckForBoxing(node, GetType(node.Type), node.Target.ExpressionType);
+		}
+
+		public override void OnTryCastExpression(TryCastExpression node)
+		{
+			base.OnTryCastExpression(node);
+			CheckForBoxing(node, GetType(node.Type), node.Target.ExpressionType);
+		}
+
+		/// <summary>
+		/// A list and a hash hold object, so everything put in one is boxed.
+		/// </summary>
+		public override void OnListLiteralExpression(ListLiteralExpression node)
+		{
+			base.OnListLiteralExpression(node);
+			foreach (var item in node.Items)
+				CheckForBoxing(item, TypeSystemServices.ObjectType, item.ExpressionType);
+		}
+
+		public override void OnHashLiteralExpression(HashLiteralExpression node)
+		{
+			base.OnHashLiteralExpression(node);
+			foreach (var pair in node.Items)
+			{
+				CheckForBoxing(pair.First, TypeSystemServices.ObjectType, pair.First.ExpressionType);
+				CheckForBoxing(pair.Second, TypeSystemServices.ObjectType, pair.Second.ExpressionType);
+			}
+		}
+
+		/// <summary>
+		/// Every argument the call ends up passing, once the vararg and property
+		/// rewrites have settled on a signature.
+		/// </summary>
+		public override void OnMethodInvocationExpression(MethodInvocationExpression node)
+		{
+			base.OnMethodInvocationExpression(node);
+			CheckForInheritedMemberCall(node);
+
+			var callable = node.Target.Entity as IMethodBase;
+			if (callable == null)
+				return;
+
+			var parameters = callable.GetParameters();
+			for (var i = 0; i < parameters.Length && i < node.Arguments.Count; ++i)
+				CheckForBoxing(node.Arguments[i], parameters[i].Type, node.Arguments[i].ExpressionType);
+		}
+
+		/// <summary>
+		/// A byreflike value reaches an overridden member directly and an
+		/// interface member by a constrained call. One it merely inherits, such
+		/// as an object member it leaves alone, can only be reached by boxing.
+		/// </summary>
+		private void CheckForInheritedMemberCall(MethodInvocationExpression node)
+		{
+			var member = node.Target as MemberReferenceExpression;
+			if (member == null)
+				return;
+
+			var method = member.Entity as IMethod;
+			if (method == null || method.IsStatic)
+				return;
+
+			var targetType = member.Target.ExpressionType;
+			if (!TypeSystemServices.IsByRefLike(targetType))
+				return;
+
+			var declaringType = method.DeclaringType;
+			if (declaringType == null || declaringType.IsValueType || declaringType.IsInterface)
+				return;
+
+			Errors.Add(CompilerErrorFactory.CannotBoxByRefLikeType(node, targetType, declaringType));
+		}
+
+		private void CheckForBoxing(Node node, IType expectedType, IType actualType)
+		{
+			if (TypeSystemServices.WouldBoxByRefLikeType(expectedType, actualType))
+				Errors.Add(CompilerErrorFactory.CannotBoxByRefLikeType(node, actualType, expectedType));
+		}
+
+		private void CheckForByRefLikeArray(Node node, IType type)
+		{
+			while (type != null && type.IsArray)
+			{
+				type = type.ElementType;
+				if (TypeSystemServices.IsByRefLike(type))
+				{
+					if (!_reportedArrayTypes.Contains(type))
+					{
+						_reportedArrayTypes.Add(type);
+						Errors.Add(CompilerErrorFactory.ByRefLikeArrayElementType(node, type));
+					}
+					return;
+				}
+			}
+		}
+	}
+}

--- a/src/Boo.Lang.Compiler/Steps/EmitAssembly.cs
+++ b/src/Boo.Lang.Compiler/Steps/EmitAssembly.cs
@@ -1706,6 +1706,22 @@ namespace Boo.Lang.Compiler.Steps
 			FlushAssignmentOperand(elementType, temp);
 		}
 
+		void SetIndirect(BinaryExpression node, IType elementType)
+		{
+			Visit(node.Left);
+			PopType();
+
+			var opcode = GetStoreRefParamCode(elementType);
+			var temp = LoadAssignmentOperand(elementType, node);
+
+			if (IsStobj(opcode))
+				_il.Emit(opcode, GetSystemType(elementType));
+			else
+				_il.Emit(opcode);
+
+			FlushAssignmentOperand(elementType, temp);
+		}
+
 		private void FlushAssignmentOperand(IType elementType, LocalBuilder temp)
 		{
 			if (temp != null)
@@ -1777,6 +1793,15 @@ namespace Boo.Lang.Compiler.Steps
 			if (NodeType.SlicingExpression == node.Left.NodeType)
 			{
 				OnAssignmentToSlice(node);
+				return;
+			}
+
+			// a byref-returning member, such as Span's indexer, is stored
+			// through the address it leaves on the stack
+			if (NodeType.MethodInvocationExpression == node.Left.NodeType
+				&& node.Left.ExpressionType != null && node.Left.ExpressionType.IsByRef)
+			{
+				SetIndirect(node, node.Left.ExpressionType.ElementType);
 				return;
 			}
 
@@ -2598,6 +2623,13 @@ namespace Boo.Lang.Compiler.Steps
 			{
 				if (methodToBeInvoked.DeclaringType.IsValueType)
 					LoadAddress(target);
+				else if (TypeSystemServices.IsByRefLike(targetType))
+				{
+					// Never boxed. The interface member is reached by a
+					// constrained call on the address instead.
+					LoadAddress(target);
+					EmitConstrained(targetType);
+				}
 				else
 				{
 					Visit(target);
@@ -3490,6 +3522,15 @@ namespace Boo.Lang.Compiler.Steps
 				return;
 			}
 
+			// Reading through an address to take its address again is a round
+			// trip; the operand already is the address.
+			if (IsDereferencedByRef(expression))
+			{
+				Visit(((UnaryExpression)expression).Operand);
+				PopType();
+				return;
+			}
+
 			Visit(expression);
 			if (!AstUtil.IsIndirection(expression))
 			{
@@ -3498,6 +3539,15 @@ namespace Boo.Lang.Compiler.Steps
 				_il.Emit(OpCodes.Stloc, temp);
 				_il.Emit(OpCodes.Ldloca, temp);
 			}
+		}
+
+		private static bool IsDereferencedByRef(Expression expression)
+		{
+			if (!AstUtil.IsIndirection(expression))
+				return false;
+
+			var operandType = ((UnaryExpression)expression).Operand.ExpressionType;
+			return operandType != null && operandType.IsByRef;
 		}
 
 		private void LoadArrayElementAddress(SlicingExpression slicing)
@@ -4392,6 +4442,8 @@ namespace Boo.Lang.Compiler.Steps
 				|| (actualType is IGenericParameter && !(expectedType is IGenericParameter)))
 				EmitBox(actualType);
 		}
+
+		private void EmitConstrained(IType type) => _il.Emit(OpCodes.Constrained, GetSystemType(type));
 
 		void EmitBox(IType type)
 		{

--- a/src/Boo.Lang.Compiler/Steps/ExpandPropertiesAndEvents.cs
+++ b/src/Boo.Lang.Compiler/Steps/ExpandPropertiesAndEvents.cs
@@ -57,7 +57,7 @@ namespace Boo.Lang.Compiler.Steps
     				CodeBuilder.CreateCast(
     					TypeSystemServices.DuckType, getter));
     		else
-    			ReplaceCurrentNode(getter);
+    			ReplaceCurrentNode(CodeBuilder.CreateDereferenceIfNeeded(getter));
     	}
 
     	public override void LeaveBinaryExpression(BinaryExpression node)

--- a/src/Boo.Lang.Compiler/Steps/NormalizeIterationStatements.cs
+++ b/src/Boo.Lang.Compiler/Steps/NormalizeIterationStatements.cs
@@ -434,24 +434,14 @@ namespace Boo.Lang.Compiler.Steps
 				return CurrentEnumeratorType;
 
 			IType bestEnumeratorType = null;
-			_candidates.Clear();
 
 			//resolution order:
 			//1) type contains an applicable GetEnumerator() [whether or not type implements IEnumerator (as C# does)]
-			CurrentEnumeratorType.Resolve(_candidates, "GetEnumerator", EntityType.Method);
-			foreach (IEntity candidate in _candidates)
+			IMethod getEnumerator = TypeSystemServices.FindGetEnumerator(CurrentEnumeratorType);
+			if (null != getEnumerator)
 			{
-				IMethod m = (IMethod) candidate;
-				if (null != m.GenericInfo || 0 != m.GetParameters().Length || !m.IsPublic)
-					continue; //only check public non-generic GetEnumerator with no argument
-
-				if (!IsAssignableFrom(TypeSystemServices.IEnumeratorGenericType, m.ReturnType)
-				    && !IsAssignableFrom(TypeSystemServices.IEnumeratorType, m.ReturnType))
-					continue; //GetEnumerator does not return an IEnumerator or IEnumerator[of T]
-
-				bestEnumeratorType = m.ReturnType;
-				_bestGetEnumerator = m;
-				break;
+				bestEnumeratorType = getEnumerator.ReturnType;
+				_bestGetEnumerator = getEnumerator;
 			}
 
 			//2) type explicitly implements IEnumerable[of T]

--- a/src/Boo.Lang.Compiler/Steps/NormalizeIterationStatements.cs
+++ b/src/Boo.Lang.Compiler/Steps/NormalizeIterationStatements.cs
@@ -195,9 +195,10 @@ namespace Boo.Lang.Compiler.Steps
 
 			if (null == CurrentBestGetCurrent)
 				return; //error
-			Expression current = CodeBuilder.CreateMethodInvocation(
-				CodeBuilder.CreateReference(iterator),
-				CurrentBestGetCurrent);
+			Expression current = CodeBuilder.CreateDereferenceIfNeeded(
+				CodeBuilder.CreateMethodInvocation(
+					CodeBuilder.CreateReference(iterator),
+					CurrentBestGetCurrent));
 
 			if (1 == declarations.Count)
 			{
@@ -224,20 +225,30 @@ namespace Boo.Lang.Compiler.Steps
 			// try:
 			//   while...
 			// ensure:
-			//   d = iterator as IDisposable
-			//   d.Dispose() unless d is null
+			//   iterator.Dispose()
 			if (ownsEnumerator && IsAssignableFrom(TypeSystemServices.IDisposableType, CurrentBestEnumeratorType))
 			{
 				TryStatement tryStatement = new TryStatement();
 				tryStatement.ProtectedBlock.Add(ws);
 				tryStatement.EnsureBlock = new Block();
 			
-				CastExpression castExpression = new CastExpression();
-				castExpression.Type = CodeBuilder.CreateTypeReference(TypeSystemServices.IDisposableType);
-				castExpression.Target = CodeBuilder.CreateReference(iterator);
-				castExpression.ExpressionType = TypeSystemServices.IDisposableType;
+				// A byreflike enumerator cannot be cast to the interface, since
+				// that is a box. It is disposed through a constrained call on the
+				// enumerator itself instead.
+				Expression disposeTarget;
+				if (TypeSystemServices.IsByRefLike(CurrentBestEnumeratorType))
+					disposeTarget = CodeBuilder.CreateReference(iterator);
+				else
+				{
+					CastExpression castExpression = new CastExpression();
+					castExpression.Type = CodeBuilder.CreateTypeReference(TypeSystemServices.IDisposableType);
+					castExpression.Target = CodeBuilder.CreateReference(iterator);
+					castExpression.ExpressionType = TypeSystemServices.IDisposableType;
+					disposeTarget = castExpression;
+				}
+
 				tryStatement.EnsureBlock.Add(
-					CodeBuilder.CreateMethodInvocation(castExpression, IDisposable_Dispose));
+					CodeBuilder.CreateMethodInvocation(disposeTarget, IDisposable_Dispose));
 
 				body.Add(tryStatement);
 			}

--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
@@ -1720,7 +1720,7 @@ namespace Boo.Lang.Compiler.Steps
 					mie.Target = CodeBuilder.CreateMemberReference(target, getter);
 					BindExpressionType(mie, getter.ReturnType);
 
-					node.ParentNode.Replace(node, mie);
+					node.ParentNode.Replace(node, CodeBuilder.CreateDereferenceIfNeeded(mie));
 				}
 				else
 				{
@@ -2407,7 +2407,16 @@ namespace Boo.Lang.Compiler.Steps
 				}
 
 				if (EntityType.Method != member.EntityType)
-					BindExpressionType(node, GetInferredType(member));
+				{
+					var memberType = GetInferredType(member);
+
+					// A byref-returning property is read for its value; the
+					// expansion step loads through the address its getter returns
+					if (memberType.IsByRef && !node.IsTargetOfAssignment())
+						memberType = memberType.ElementType;
+
+					BindExpressionType(node, memberType);
+				}
 				else
 					BindExpressionType(node, member.Type);
 			}
@@ -4267,6 +4276,29 @@ namespace Boo.Lang.Compiler.Steps
 			EnsureRelatedNodeWasVisited(node.Target, targetMethod);
 			BindExpressionType(node, GetInferredType(targetMethod));
 			ApplyBuiltinMethodTypeInference(node, targetMethod);
+			DereferenceByRefReturn(node);
+		}
+
+		/// <summary>
+		/// A method returning 'ref T' hands back an address; the call reads it
+		/// for its value. The operand is attached after the swap so that
+		/// building the indirection does not reparent the node first.
+		/// </summary>
+		private void DereferenceByRefReturn(MethodInvocationExpression node)
+		{
+			var type = node.ExpressionType;
+			if (type == null || !type.IsByRef || node.ParentNode == null)
+				return;
+
+			// Assigning to the call stores through the address, so the address
+			// is what the left hand side wants to keep.
+			if (node.IsTargetOfAssignment())
+				return;
+
+			var indirection = new UnaryExpression(node.LexicalInfo) { Operator = UnaryOperatorType.Indirection };
+			BindExpressionType(indirection, type.ElementType);
+			node.ParentNode.Replace(node, indirection);
+			indirection.Operand = node;
 		}
 
 		private void FixAmbiguousSignatures(MethodInvocationExpression node)
@@ -4847,6 +4879,17 @@ namespace Boo.Lang.Compiler.Steps
 			if (IsError(lhs))
 				return;
 
+			// A byref-returning indexer, such as Span's, has no setter; it is
+			// assigned through the address its getter hands back. A readonly
+			// ref, as ReadOnlySpan returns, stays read only.
+			var indexer = lhs as IProperty;
+			if (indexer != null && indexer.GetSetMethod() == null && indexer.Type.IsByRef
+				&& !TypeSystemServices.IsReadOnlyByRef(indexer.GetGetMethod()))
+			{
+				BindIndirectAssignmentToSliceProperty(node, slice, indexer);
+				return;
+			}
+
 			var mie = new MethodInvocationExpression(node.Left.LexicalInfo);
 			foreach (var index in slice.Indices)
 				mie.Arguments.Add(index.Begin);
@@ -4895,6 +4938,22 @@ namespace Boo.Lang.Compiler.Steps
 			}
 		}
 
+		void BindIndirectAssignmentToSliceProperty(BinaryExpression node, SlicingExpression slice, IProperty property)
+		{
+			var getter = property.GetGetMethod();
+			var mie = new MethodInvocationExpression(node.Left.LexicalInfo);
+			foreach (var index in slice.Indices)
+				mie.Arguments.Add(index.Begin);
+
+			mie.Target = CodeBuilder.CreateMemberReference(
+				GetIndexedPropertySlicingTarget(slice),
+				getter);
+			BindExpressionType(mie, getter.ReturnType);
+
+			node.Left = mie;
+			BindExpressionType(node, property.Type.ElementType);
+		}
+
 		private IEntity[] GetSetMethods(IEntity candidates)
 		{
 			return GetSetMethods(((Ambiguous)candidates).Entities);
@@ -4907,7 +4966,33 @@ namespace Boo.Lang.Compiler.Steps
 			if (NodeType.SlicingExpression == node.Left.NodeType)
 				BindAssignmentToSlice(node);
 			else
+			{
+				RewriteByRefPropertyAssignment(node);
 				ProcessAssignment(node);
+			}
+		}
+
+		/// <summary>
+		/// A byref-returning property has no setter, as Span's enumerator shows.
+		/// It is written through the address its getter hands back.
+		/// </summary>
+		private void RewriteByRefPropertyAssignment(BinaryExpression node)
+		{
+			var member = node.Left as MemberReferenceExpression;
+			if (member == null)
+				return;
+
+			var property = member.Entity as IProperty;
+			if (property == null || !property.Type.IsByRef || property.GetSetMethod() != null)
+				return;
+
+			var getter = property.GetGetMethod();
+			if (getter == null || TypeSystemServices.IsReadOnlyByRef(getter))
+				return;
+
+			var mie = CodeBuilder.CreateMethodInvocation(member.Target, getter);
+			BindExpressionType(mie, getter.ReturnType);
+			node.Left = mie;
 		}
 
 		virtual protected void ProcessAssignment(BinaryExpression node)
@@ -4924,7 +5009,11 @@ namespace Boo.Lang.Compiler.Steps
 			if (!AssertLValue(node.Left))
 				return false;
 
+			// Storing through an address is storing into what it points at.
 			IType lhsType = GetExpressionType(node.Left);
+			if (lhsType.IsByRef)
+				lhsType = lhsType.ElementType;
+
 			IType rhsType = GetExpressionType(node.Right);
 			if (!AssertTypeCompatibility(node.Right, lhsType, rhsType))
 				return false;
@@ -5548,6 +5637,11 @@ namespace Boo.Lang.Compiler.Steps
 			return TypeChecker.CanBeReachedFrom(anchor, expectedType, actualType);
 		}
 
+		bool CanBeReachedFrom(Node anchor, IType expectedType, IType actualType, bool reportErrors)
+		{
+			return TypeChecker.CanBeReachedFrom(anchor, expectedType, actualType, reportErrors);
+		}
+
 		private TypeChecker TypeChecker
 		{
 			get { return _typeChecker.Instance; }
@@ -5594,6 +5688,7 @@ namespace Boo.Lang.Compiler.Steps
 				{
 					if (!(args[i] is ReferenceExpression
 						|| args[i] is SlicingExpression
+						|| IsDereferencedByRef(args[i])
 						|| (args[i] is SelfLiteralExpression && argumentType.IsValueType)))
 					{
 						if (reportErrors)
@@ -5607,7 +5702,7 @@ namespace Boo.Lang.Compiler.Steps
 				}
 				else
 				{
-					if (!CanBeReachedFrom(args[i], parameterType, argumentType))
+					if (!CanBeReachedFrom(args[i], parameterType, argumentType, reportErrors))
 						return false;
 				}
 			}
@@ -5629,10 +5724,24 @@ namespace Boo.Lang.Compiler.Steps
 			if (CheckParameters(method, args, true))
 				return true;
 
+			// An argument that cannot be boxed has already named the problem;
+			// the signature mismatch would only repeat it.
+			if (HasUnboxableByRefLikeArgument(method, args))
+				return false;
+
 			if (IsLikelyMacroExtensionMethodInvocation(sourceEntity))
 				Error(CompilerErrorFactory.MacroExpansionError(sourceNode));
 			else
 				Error(CompilerErrorFactory.MethodSignature(sourceNode, sourceEntity, GetSignature(args)));
+			return false;
+		}
+
+		bool HasUnboxableByRefLikeArgument(ICallableType method, ExpressionCollection args)
+		{
+			var parameters = method.GetSignature().Parameters;
+			for (var i = 0; i < parameters.Length && i < args.Count; ++i)
+				if (TypeSystemServices.WouldBoxByRefLikeType(parameters[i].Type, GetExpressionType(args[i])))
+					return true;
 			return false;
 		}
 
@@ -6213,6 +6322,9 @@ namespace Boo.Lang.Compiler.Steps
 			if (IsError(GetExpressionType(node)))
 				return false;
 
+			if (IsWritableByRef(node))
+				return true;
+
 			var entity = node.Entity;
 			if (null != entity)
 				return AssertLValue(node, entity);
@@ -6222,6 +6334,49 @@ namespace Boo.Lang.Compiler.Steps
 
 			LValueExpected(node);
 			return false;
+		}
+
+		/// <summary>
+		/// An expression of type 'ref T' is the address of a real location, and
+		/// as assignable as the location itself. A 'ref readonly T' is not.
+		/// </summary>
+		private static bool IsWritableByRef(Expression node)
+		{
+			var type = node.ExpressionType;
+			if (type == null || !type.IsByRef)
+				return false;
+
+			var method = ByRefMemberOf(node);
+			return method == null || !TypeSystemServices.IsReadOnlyByRef(method);
+		}
+
+		/// <summary>
+		/// A byref-returning member read for its value, as span[i] is. The
+		/// address behind it is what a ref argument wants.
+		/// </summary>
+		private static bool IsDereferencedByRef(Expression node)
+		{
+			if (!AstUtil.IsIndirection(node))
+				return false;
+
+			var operand = ((UnaryExpression)node).Operand;
+			return operand.ExpressionType != null
+				&& operand.ExpressionType.IsByRef
+				&& IsWritableByRef(operand);
+		}
+
+		/// <summary>
+		/// The member that handed back the address, whether the source spelled
+		/// it as a call or as a property.
+		/// </summary>
+		private static IMethod ByRefMemberOf(Expression node)
+		{
+			var invocation = node as MethodInvocationExpression;
+			if (invocation != null)
+				return invocation.Target.Entity as IMethod;
+
+			var property = node.Entity as IProperty;
+			return property == null ? null : property.GetGetMethod();
 		}
 
 		private void LValueExpected(Node node)

--- a/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericConstructionChecker.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Generics/GenericConstructionChecker.cs
@@ -145,6 +145,12 @@ namespace Boo.Lang.Compiler.TypeSystem.Generics
 				return false;
 			}
 
+			if (TypeSystemServices.IsByRefLike(argument))
+			{
+				Errors.Add(CompilerErrorFactory.ByRefLikeGenericArgument(ConstructionNode, argument));
+				return false;
+			}
+
 			bool valid = true;
 
 			// Check type semantics constraints

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/BooCodeBuilder.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/BooCodeBuilder.cs
@@ -682,6 +682,25 @@ namespace Boo.Lang.Compiler.TypeSystem
 			       	};
 		}
 
+		/// <summary>
+		/// Loads through the address a byref-returning member hands back, for a
+		/// reader that wants the value rather than the location.
+		/// </summary>
+		public Expression CreateDereferenceIfNeeded(Expression node)
+		{
+			var type = node.ExpressionType;
+			if (type == null || !type.IsByRef)
+				return node;
+
+			return new UnaryExpression
+			       	{
+			       		LexicalInfo = node.LexicalInfo,
+			       		Operand = node,
+			       		Operator = UnaryOperatorType.Indirection,
+			       		ExpressionType = type.ElementType
+			       	};
+		}
+
 		public UnaryExpression CreateNotExpression(Expression node)
 		{
 			return new UnaryExpression

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/TypeChecker.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/TypeChecker.cs
@@ -22,7 +22,10 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 
 			if (!CanBeReachedFrom(sourceNode, expectedType, actualType))
 			{
-				_errors.Instance.Add(CompilerErrorFactory.IncompatibleExpressionType(sourceNode, expectedType, actualType));
+				// CanBeReachedFrom has already said why a byreflike value cannot
+				// get there, and it is not that the types are incompatible.
+				if (!WouldBoxByRefLikeType(expectedType, actualType))
+					_errors.Instance.Add(CompilerErrorFactory.IncompatibleExpressionType(sourceNode, expectedType, actualType));
 				return false;
 			}
 			return true;
@@ -30,12 +33,34 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 
 		public bool CanBeReachedFrom(Node anchor, IType expectedType, IType actualType)
 		{
+			return CanBeReachedFrom(anchor, expectedType, actualType, true);
+		}
+
+		/// <summary>
+		/// Overload resolution asks the same question twice, once to pick a
+		/// candidate and once to complain about the one it picked. Only the
+		/// second time is anyone listening.
+		/// </summary>
+		public bool CanBeReachedFrom(Node anchor, IType expectedType, IType actualType, bool reportErrors)
+		{
+			if (WouldBoxByRefLikeType(expectedType, actualType))
+			{
+				if (reportErrors)
+					_errors.Instance.Add(CompilerErrorFactory.CannotBoxByRefLikeType(anchor, actualType, expectedType));
+				return false;
+			}
+
 			bool byDowncast;
 			if (!_typeSystemServices.Instance.CanBeReachedFrom(expectedType, actualType, out byDowncast))
 				return false;
 			if (byDowncast)
 				_warnings.Instance.Add(CompilerWarningFactory.ImplicitDowncast(anchor, expectedType, actualType));
 			return true;
+		}
+
+		private static bool WouldBoxByRefLikeType(IType expectedType, IType actualType)
+		{
+			return TypeSystemServices.WouldBoxByRefLikeType(expectedType, actualType);
 		}
 
 		private static bool IsError(IEntity entity)

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/TypeChecker.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/TypeChecker.cs
@@ -24,7 +24,7 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 			{
 				// CanBeReachedFrom has already said why a byreflike value cannot
 				// get there, and it is not that the types are incompatible.
-				if (!WouldBoxByRefLikeType(expectedType, actualType))
+				if (!TypeSystemServices.WouldBoxByRefLikeType(expectedType, actualType))
 					_errors.Instance.Add(CompilerErrorFactory.IncompatibleExpressionType(sourceNode, expectedType, actualType));
 				return false;
 			}
@@ -43,7 +43,7 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 		/// </summary>
 		public bool CanBeReachedFrom(Node anchor, IType expectedType, IType actualType, bool reportErrors)
 		{
-			if (WouldBoxByRefLikeType(expectedType, actualType))
+			if (TypeSystemServices.WouldBoxByRefLikeType(expectedType, actualType))
 			{
 				if (reportErrors)
 					_errors.Instance.Add(CompilerErrorFactory.CannotBoxByRefLikeType(anchor, actualType, expectedType));
@@ -56,11 +56,6 @@ namespace Boo.Lang.Compiler.TypeSystem.Services
 			if (byDowncast)
 				_warnings.Instance.Add(CompilerWarningFactory.ImplicitDowncast(anchor, expectedType, actualType));
 			return true;
-		}
-
-		private static bool WouldBoxByRefLikeType(IType expectedType, IType actualType)
-		{
-			return TypeSystemServices.WouldBoxByRefLikeType(expectedType, actualType);
 		}
 
 		private static bool IsError(IEntity entity)

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
@@ -488,17 +488,42 @@ namespace Boo.Lang.Compiler.TypeSystem
 			return ObjectType;
 		}
 
-		private static IType GetExplicitEnumeratorItemType(IType iteratorType)
+		private IType GetExplicitEnumeratorItemType(IType iteratorType)
 		{
-			var ge = iteratorType.GetMembers().OfType<IMethod>().FirstOrDefault(m => m.Name == "GetEnumerator");
-			if (ge == null) return null;
-			var eType = ge.ReturnType;
-			var current = eType.GetMembers().OfType<IProperty>().FirstOrDefault(p => p.Name == "Current");
-			var itemType = current?.Type;
+			var getEnumerator = FindGetEnumerator(iteratorType);
+			if (null == getEnumerator) return null;
+
+			var current = getEnumerator.ReturnType.GetMembers()
+				.OfType<IProperty>().FirstOrDefault(p => p.Name == "Current");
+			if (null == current) return null;
 
 			// An enumerator handing back 'ref T' still fills the loop variable
 			// with a value
-			return itemType != null && itemType.IsByRef ? itemType.ElementType : itemType;
+			return current.Type.IsByRef ? current.Type.ElementType : current.Type;
+		}
+
+		/// <summary>
+		/// The GetEnumerator a for statement would call on the type: public,
+		/// taking no arguments, not generic, and returning an enumerator.
+		/// Whoever asks what the loop variable holds and whoever emits the loop
+		/// have to agree on which one that is.
+		/// </summary>
+		public IMethod FindGetEnumerator(IType type)
+		{
+			var candidates = new List<IEntity>();
+			type.Resolve(candidates, "GetEnumerator", EntityType.Method);
+
+			foreach (IMethod candidate in candidates.OfType<IMethod>())
+			{
+				if (null != candidate.GenericInfo || 0 != candidate.GetParameters().Length || !candidate.IsPublic)
+					continue;
+
+				if (IsAssignableFrom(IEnumeratorGenericType, candidate.ReturnType)
+					|| IsAssignableFrom(IEnumeratorType, candidate.ReturnType))
+					return candidate;
+			}
+
+			return null;
 		}
 
 		public static IType GetExpressionType(Expression node)

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
@@ -480,8 +480,25 @@ namespace Boo.Lang.Compiler.TypeSystem
 			IType genericItemType = GetGenericEnumerableItemType(iteratorType);
 			if (null != genericItemType) return genericItemType;
 
+			// Try to find a GetEnumerator method
+			IType explicitEnumeratorType = GetExplicitEnumeratorItemType(iteratorType);
+			if (null != explicitEnumeratorType) return explicitEnumeratorType;
+
 			// If none of these work, the type is an enumerator of object
 			return ObjectType;
+		}
+
+		private static IType GetExplicitEnumeratorItemType(IType iteratorType)
+		{
+			var ge = iteratorType.GetMembers().OfType<IMethod>().FirstOrDefault(m => m.Name == "GetEnumerator");
+			if (ge == null) return null;
+			var eType = ge.ReturnType;
+			var current = eType.GetMembers().OfType<IProperty>().FirstOrDefault(p => p.Name == "Current");
+			var itemType = current?.Type;
+
+			// An enumerator handing back 'ref T' still fills the loop variable
+			// with a value
+			return itemType != null && itemType.IsByRef ? itemType.ElementType : itemType;
 		}
 
 		public static IType GetExpressionType(Expression node)
@@ -569,6 +586,9 @@ namespace Boo.Lang.Compiler.TypeSystem
 		public bool CanBeReachedFrom(IType expectedType, IType actualType, bool considerExplicitConversionOperators, out bool byDowncast)
 		{
 			byDowncast = false;
+			if (WouldBoxByRefLikeType(expectedType, actualType))
+				return false;
+
 			return IsAssignableFrom(expectedType, actualType)
 			       || CanBeReachedByPromotion(expectedType, actualType)
 			       || FindImplicitConversionOperator(actualType, expectedType) != null
@@ -579,6 +599,60 @@ namespace Boo.Lang.Compiler.TypeSystem
 		private DowncastPermissions DowncastPermissions()
 		{
 			return _downcastPermissions ?? (_downcastPermissions = My<DowncastPermissions>.Instance);
+		}
+
+		/// <summary>
+		/// A byreflike value reaches a reference type only by being boxed, which
+		/// is the one thing the runtime will not do with it.
+		/// </summary>
+		public static bool WouldBoxByRefLikeType(IType expectedType, IType actualType)
+		{
+			return null != expectedType && !expectedType.IsValueType && IsByRefLike(actualType);
+		}
+
+		/// <summary>
+		/// A byreflike type is one the runtime keeps on the stack, such as Span.
+		/// </summary>
+		public static bool IsByRefLike(IType type)
+		{
+			// Every byreflike type is a struct, and most types asked about are
+			// not, so this settles it without looking any further.
+			if (null == type || !type.IsValueType)
+				return false;
+
+			if (type is ExternalType external)
+				return external.ActualType.IsByRefLike;
+
+			// A constructed type is byreflike when the definition behind it is
+			if (null != type.ConstructedInfo)
+				return IsByRefLike(type.ConstructedInfo.GenericDefinition);
+
+			// A Boo struct carries the marker as an ordinary attribute
+			var internalType = type as AbstractInternalType;
+			return internalType != null
+				&& internalType.TypeDefinition.Attributes.Count > 0
+				&& internalType.TypeDefinition.Attributes.Any(IsByRefLikeAttribute);
+		}
+
+		private static readonly string ByRefLikeAttributeName =
+			typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute).FullName;
+
+		private static bool IsByRefLikeAttribute(Ast.Attribute attribute)
+		{
+			var constructor = GetEntity(attribute) as IConstructor;
+			return constructor != null && constructor.DeclaringType.FullName == ByRefLikeAttributeName;
+		}
+
+		/// <summary>
+		/// A member returning 'ref readonly T', such as the ReadOnlySpan indexer,
+		/// marks its return with an In modifier. The address is not assignable.
+		/// </summary>
+		public static bool IsReadOnlyByRef(IMethod method)
+		{
+			var mi = (method as ExternalMethod)?.MethodInfo as System.Reflection.MethodInfo;
+			return mi != null
+				&& mi.ReturnParameter.GetRequiredCustomModifiers()
+					.Any(m => m.FullName == "System.Runtime.InteropServices.InAttribute");
 		}
 
 		private bool InStrictMode()

--- a/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
+++ b/src/Boo.Lang.Compiler/TypeSystem/Services/TypeSystemServices.cs
@@ -134,6 +134,8 @@ namespace Boo.Lang.Compiler.TypeSystem
 		private readonly MemoizedFunction<IType, IType, bool> _canBeReachedByPromotion;
 		private readonly AnonymousCallablesManager _anonymousCallablesManager;
 		private readonly CompilerContext _context;
+		private static readonly string ByRefLikeAttributeName =
+			typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute).FullName;
 
 		public TypeSystemServices() : this(CompilerContext.Current)
 		{
@@ -655,12 +657,8 @@ namespace Boo.Lang.Compiler.TypeSystem
 			// A Boo struct carries the marker as an ordinary attribute
 			var internalType = type as AbstractInternalType;
 			return internalType != null
-				&& internalType.TypeDefinition.Attributes.Count > 0
 				&& internalType.TypeDefinition.Attributes.Any(IsByRefLikeAttribute);
 		}
-
-		private static readonly string ByRefLikeAttributeName =
-			typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute).FullName;
 
 		private static bool IsByRefLikeAttribute(Ast.Attribute attribute)
 		{
@@ -671,6 +669,8 @@ namespace Boo.Lang.Compiler.TypeSystem
 		/// <summary>
 		/// A member returning 'ref readonly T', such as the ReadOnlySpan indexer,
 		/// marks its return with an In modifier. The address is not assignable.
+		/// Only external members are asked, which is enough while Boo has no
+		/// syntax for declaring one.
 		/// </summary>
 		public static bool IsReadOnlyByRef(IMethod method)
 		{

--- a/src/Boo.Lang.Parser/BooParser.g4
+++ b/src/Boo.Lang.Parser/BooParser.g4
@@ -118,10 +118,12 @@ type_member
 	;
 
 type_definition
-	:	class_definition
-	|	interface_definition
-	|	enum_definition
-	|	callable_definition
+	:	REF?
+		(	class_definition
+		|	interface_definition
+		|	enum_definition
+		|	callable_definition
+		)
 	;
 	
 callable_definition

--- a/src/Boo.Lang.Parser/BooParserAstBuilderVisitor.cs
+++ b/src/Boo.Lang.Parser/BooParserAstBuilderVisitor.cs
@@ -18,6 +18,9 @@ internal class BooParserAstBuilderVisitor : AbstractParseTreeVisitor<Node>, IBoo
 	private readonly string _filename;
 	private readonly StringBuilder _sbuilder = new StringBuilder();
 
+	private static readonly string ByRefLikeAttributeName =
+		typeof(System.Runtime.CompilerServices.IsByRefLikeAttribute).FullName;
+
 	private readonly ParseTreeProperty<MacroStatement> _macroStatement = new ParseTreeProperty<MacroStatement>();
 	private readonly ParseTreeProperty<Node> _node = new ParseTreeProperty<Node>();
 	private readonly ParseTreeProperty<Import> _import = new ParseTreeProperty<Import>();
@@ -228,6 +231,16 @@ internal class BooParserAstBuilderVisitor : AbstractParseTreeVisitor<Node>, IBoo
 			CompilerErrorFactory.GenericParserError(
 				location,
 				new Exception(Boo.Lang.Resources.StringResources.BooParser_DuplicateDocstring)));
+	}
+
+	protected virtual void EmitRefTypeDefinitionError(LexicalInfo location)
+	{
+		if (OutsideCompilationEnvironment())
+			return;
+		EmitError(
+			CompilerErrorFactory.GenericParserError(
+				location,
+				new Exception(Boo.Lang.Resources.StringResources.BooParser_RefOnNonStruct)));
 	}
 
 	protected virtual void EmitParamAfterVarargsError(LexicalInfo location)
@@ -622,13 +635,37 @@ internal class BooParserAstBuilderVisitor : AbstractParseTreeVisitor<Node>, IBoo
 		if (context == null)
 			return null;
 
+		TypeMember result;
 		if (context.class_definition() != null)
-			return VisitClass_definition(context.class_definition());
-		if (context.interface_definition() != null)
-			return VisitInterface_definition(context.interface_definition());
-		if (context.enum_definition() != null)
-			return VisitEnum_definition(context.enum_definition());
-		return VisitCallable_definition(context.callable_definition());
+			result = VisitClass_definition(context.class_definition());
+		else if (context.interface_definition() != null)
+			result = VisitInterface_definition(context.interface_definition());
+		else if (context.enum_definition() != null)
+			result = VisitEnum_definition(context.enum_definition());
+		else
+			result = VisitCallable_definition(context.callable_definition());
+
+		if (context.REF() != null)
+			ApplyRefModifier(result, GetLexicalInfo(context.REF()));
+		return result;
+	}
+
+	/// <summary>
+	/// 'ref struct' is spelled downstream as the IsByRefLike attribute, which is
+	/// what the runtime and an external assembly both read.
+	/// </summary>
+	private void ApplyRefModifier(TypeMember type, LexicalInfo location)
+	{
+		var splice = type as SpliceTypeMember;
+		var target = (splice == null ? type : splice.TypeMember) as StructDefinition;
+		if (target == null)
+		{
+			EmitRefTypeDefinitionError(location);
+			return;
+		}
+
+		target.Attributes.Add(
+			new Boo.Lang.Compiler.Ast.Attribute(location, ByRefLikeAttributeName));
 	}
 
 	Node IBooParserVisitor<Node>.VisitType_definition(BooParser.Type_definitionContext context)

--- a/src/Boo.Lang.Parser/Generated/BooParser.cs
+++ b/src/Boo.Lang.Parser/Generated/BooParser.cs
@@ -1060,6 +1060,7 @@ public partial class BooParser : Parser {
 			case CLASS:
 			case ENUM:
 			case INTERFACE:
+			case REF:
 			case STRUCT:
 				{
 				State = 427;
@@ -1101,6 +1102,7 @@ public partial class BooParser : Parser {
 		[System.Diagnostics.DebuggerNonUserCode] public Callable_definitionContext callable_definition() {
 			return GetRuleContext<Callable_definitionContext>(0);
 		}
+		[System.Diagnostics.DebuggerNonUserCode] public ITerminalNode REF() { return GetToken(BooParser.REF, 0); }
 		public Type_definitionContext(ParserRuleContext parent, int invokingState)
 			: base(parent, invokingState)
 		{
@@ -1118,41 +1120,51 @@ public partial class BooParser : Parser {
 	public Type_definitionContext type_definition() {
 		Type_definitionContext _localctx = new Type_definitionContext(Context, State);
 		EnterRule(_localctx, 24, RULE_type_definition);
+		int _la;
 		try {
-			State = 435;
+			EnterOuterAlt(_localctx, 1);
+			{
+			State = 432;
+			ErrorHandler.Sync(this);
+			_la = TokenStream.LA(1);
+			if (_la==REF) {
+				{
+				State = 431;
+				Match(REF);
+				}
+			}
+
+			State = 438;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case CLASS:
 			case STRUCT:
-				EnterOuterAlt(_localctx, 1);
 				{
-				State = 431;
+				State = 434;
 				class_definition();
 				}
 				break;
 			case INTERFACE:
-				EnterOuterAlt(_localctx, 2);
 				{
-				State = 432;
+				State = 435;
 				interface_definition();
 				}
 				break;
 			case ENUM:
-				EnterOuterAlt(_localctx, 3);
 				{
-				State = 433;
+				State = 436;
 				enum_definition();
 				}
 				break;
 			case CALLABLE:
-				EnterOuterAlt(_localctx, 4);
 				{
-				State = 434;
+				State = 437;
 				callable_definition();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
+			}
 			}
 		}
 		catch (RecognitionException re) {
@@ -1211,55 +1223,55 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 437;
+			State = 440;
 			Match(CALLABLE);
-			State = 438;
+			State = 441;
 			Match(ID);
-			State = 446;
+			State = 449;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LBRACK) {
 				{
-				State = 439;
+				State = 442;
 				Match(LBRACK);
-				State = 441;
+				State = 444;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 440;
+					State = 443;
 					Match(OF);
 					}
 				}
 
-				State = 443;
+				State = 446;
 				generic_parameter_declaration_list();
-				State = 444;
+				State = 447;
 				Match(RBRACK);
 				}
 			}
 
-			State = 448;
+			State = 451;
 			Match(LPAREN);
-			State = 449;
+			State = 452;
 			parameter_declaration_list();
-			State = 450;
-			Match(RPAREN);
 			State = 453;
+			Match(RPAREN);
+			State = 456;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 451;
+				State = 454;
 				Match(AS);
-				State = 452;
+				State = 455;
 				type_reference();
 				}
 			}
 
-			State = 455;
+			State = 458;
 			eos();
-			State = 456;
+			State = 459;
 			docstring();
 			}
 		}
@@ -1314,20 +1326,20 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 458;
+			State = 461;
 			Match(ENUM);
-			State = 459;
+			State = 462;
 			Match(ID);
-			State = 460;
+			State = 463;
 			begin_with_doc();
-			State = 468;
+			State = 471;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case PASS:
 				{
-				State = 461;
+				State = 464;
 				Match(PASS);
-				State = 462;
+				State = 465;
 				eos();
 				}
 				break;
@@ -1335,17 +1347,17 @@ public partial class BooParser : Parser {
 			case LBRACK:
 			case SPLICE_BEGIN:
 				{
-				State = 464;
+				State = 467;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				do {
 					{
 					{
-					State = 463;
+					State = 466;
 					any_enum_member();
 					}
 					}
-					State = 466;
+					State = 469;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				} while ( ((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & 8519681L) != 0) );
@@ -1354,7 +1366,7 @@ public partial class BooParser : Parser {
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 470;
+			State = 473;
 			end();
 			}
 		}
@@ -1396,19 +1408,19 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 474;
+			State = 477;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ID:
 			case LBRACK:
 				{
-				State = 472;
+				State = 475;
 				enum_member();
 				}
 				break;
 			case SPLICE_BEGIN:
 				{
-				State = 473;
+				State = 476;
 				splice_type_definition_body();
 				}
 				break;
@@ -1464,25 +1476,25 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 476;
+			State = 479;
 			attributes();
-			State = 477;
-			Match(ID);
 			State = 480;
+			Match(ID);
+			State = 483;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==ASSIGN) {
 				{
-				State = 478;
+				State = 481;
 				Match(ASSIGN);
-				State = 479;
+				State = 482;
 				simple_initializer();
 				}
 			}
 
-			State = 482;
+			State = 485;
 			eos();
-			State = 483;
+			State = 486;
 			docstring();
 			}
 		}
@@ -1543,55 +1555,55 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 502;
+			State = 505;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==LBRACK) {
 				{
 				{
-				State = 485;
+				State = 488;
 				Match(LBRACK);
-				State = 494;
+				State = 497;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (((((_la - 61)) & ~0x3f) == 0 && ((1L << (_la - 61)) & 517L) != 0)) {
 					{
-					State = 486;
+					State = 489;
 					attribute();
-					State = 491;
+					State = 494;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					while (_la==COMMA) {
 						{
 						{
-						State = 487;
+						State = 490;
 						Match(COMMA);
-						State = 488;
+						State = 491;
 						attribute();
 						}
 						}
-						State = 493;
+						State = 496;
 						ErrorHandler.Sync(this);
 						_la = TokenStream.LA(1);
 					}
 					}
 				}
 
-				State = 496;
+				State = 499;
 				Match(RBRACK);
-				State = 498;
+				State = 501;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==EOL || _la==EOS) {
 					{
-					State = 497;
+					State = 500;
 					eos();
 					}
 				}
 
 				}
 				}
-				State = 504;
+				State = 507;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -1639,35 +1651,35 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 507;
+			State = 510;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case THEN:
 			case ID:
 				{
-				State = 505;
+				State = 508;
 				identifier();
 				}
 				break;
 			case TRANSIENT:
 				{
-				State = 506;
+				State = 509;
 				Match(TRANSIENT);
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 513;
+			State = 516;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LPAREN) {
 				{
-				State = 509;
+				State = 512;
 				Match(LPAREN);
-				State = 510;
+				State = 513;
 				argument_list();
-				State = 511;
+				State = 514;
 				Match(RPAREN);
 				}
 			}
@@ -1711,11 +1723,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 515;
+			State = 518;
 			Match(MODULE_ATTRIBUTE_BEGIN);
-			State = 516;
+			State = 519;
 			attribute();
-			State = 517;
+			State = 520;
 			Match(RBRACK);
 			}
 		}
@@ -1756,11 +1768,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 519;
+			State = 522;
 			Match(ASSEMBLY_ATTRIBUTE_BEGIN);
-			State = 520;
+			State = 523;
 			attribute();
-			State = 521;
+			State = 524;
 			Match(RBRACK);
 			}
 		}
@@ -1802,18 +1814,18 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 525;
+			State = 528;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,32,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,33,Context) ) {
 			case 1:
 				{
-				State = 523;
+				State = 526;
 				splice_type_definition_body();
 				}
 				break;
 			case 2:
 				{
-				State = 524;
+				State = 527;
 				type_definition_member();
 				}
 				break;
@@ -1885,7 +1897,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 527;
+			State = 530;
 			_la = TokenStream.LA(1);
 			if ( !(_la==CLASS || _la==STRUCT) ) {
 			ErrorHandler.RecoverInline(this);
@@ -1894,70 +1906,70 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 531;
+			State = 534;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ID:
 				{
-				State = 528;
+				State = 531;
 				Match(ID);
 				}
 				break;
 			case SPLICE_BEGIN:
 				{
-				State = 529;
+				State = 532;
 				Match(SPLICE_BEGIN);
-				State = 530;
+				State = 533;
 				atom();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 540;
+			State = 543;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LBRACK) {
 				{
-				State = 533;
+				State = 536;
 				Match(LBRACK);
-				State = 535;
+				State = 538;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 534;
+					State = 537;
 					Match(OF);
 					}
 				}
 
-				State = 537;
+				State = 540;
 				generic_parameter_declaration_list();
-				State = 538;
+				State = 541;
 				Match(RBRACK);
 				}
 			}
 
-			State = 543;
+			State = 546;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LPAREN) {
 				{
-				State = 542;
+				State = 545;
 				base_types();
 				}
 			}
 
-			State = 545;
+			State = 548;
 			begin_with_doc();
-			State = 556;
+			State = 559;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case PASS:
 				{
-				State = 546;
+				State = 549;
 				Match(PASS);
-				State = 547;
+				State = 550;
 				eos();
 				}
 				break;
@@ -1977,6 +1989,7 @@ public partial class BooParser : Parser {
 			case PUBLIC:
 			case PROTECTED:
 			case PRIVATE:
+			case REF:
 			case SELF:
 			case STATIC:
 			case STRUCT:
@@ -1988,36 +2001,36 @@ public partial class BooParser : Parser {
 			case SPLICE_BEGIN:
 			case EOS:
 				{
-				State = 549;
+				State = 552;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==EOL || _la==EOS) {
 					{
-					State = 548;
+					State = 551;
 					eos();
 					}
 				}
 
-				State = 552;
+				State = 555;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				do {
 					{
 					{
-					State = 551;
+					State = 554;
 					any_type_definition_member();
 					}
 					}
-					State = 554;
+					State = 557;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
-				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & -5035442094420619136L) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & 68157449L) != 0) );
+				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & -5017427695911137152L) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & 68157449L) != 0) );
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 558;
+			State = 561;
 			end();
 			}
 		}
@@ -2060,11 +2073,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 560;
+			State = 563;
 			Match(SPLICE_BEGIN);
-			State = 561;
+			State = 564;
 			atom();
-			State = 562;
+			State = 565;
 			eos();
 			}
 		}
@@ -2118,22 +2131,22 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 564;
+			State = 567;
 			attributes();
-			State = 565;
+			State = 568;
 			modifiers();
-			State = 570;
+			State = 573;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case DEF:
 				{
-				State = 566;
+				State = 569;
 				method();
 				}
 				break;
 			case EVENT:
 				{
-				State = 567;
+				State = 570;
 				event_declaration();
 				}
 				break;
@@ -2142,7 +2155,7 @@ public partial class BooParser : Parser {
 			case ID:
 			case SPLICE_BEGIN:
 				{
-				State = 568;
+				State = 571;
 				field_or_property();
 				}
 				break;
@@ -2150,9 +2163,10 @@ public partial class BooParser : Parser {
 			case CLASS:
 			case ENUM:
 			case INTERFACE:
+			case REF:
 			case STRUCT:
 				{
-				State = 569;
+				State = 572;
 				type_definition();
 				}
 				break;
@@ -2206,27 +2220,27 @@ public partial class BooParser : Parser {
 			EnterOuterAlt(_localctx, 1);
 			{
 			{
-			State = 572;
+			State = 575;
 			attributes();
-			State = 576;
+			State = 579;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case DEF:
 				{
-				State = 573;
+				State = 576;
 				interface_method();
 				}
 				break;
 			case EVENT:
 				{
-				State = 574;
+				State = 577;
 				event_declaration();
 				}
 				break;
 			case SELF:
 			case ID:
 				{
-				State = 575;
+				State = 578;
 				interface_property();
 				}
 				break;
@@ -2300,72 +2314,72 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 578;
+			State = 581;
 			Match(INTERFACE);
-			State = 582;
+			State = 585;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ID:
 				{
-				State = 579;
+				State = 582;
 				Match(ID);
 				}
 				break;
 			case SPLICE_BEGIN:
 				{
-				State = 580;
+				State = 583;
 				Match(SPLICE_BEGIN);
-				State = 581;
+				State = 584;
 				atom();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 591;
+			State = 594;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LBRACK) {
 				{
-				State = 584;
+				State = 587;
 				Match(LBRACK);
-				State = 586;
+				State = 589;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 585;
+					State = 588;
 					Match(OF);
 					}
 				}
 
-				State = 588;
+				State = 591;
 				generic_parameter_declaration_list();
-				State = 589;
+				State = 592;
 				Match(RBRACK);
 				}
 			}
 
-			State = 594;
+			State = 597;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LPAREN) {
 				{
-				State = 593;
+				State = 596;
 				base_types();
 				}
 			}
 
-			State = 596;
+			State = 599;
 			begin_with_doc();
-			State = 604;
+			State = 607;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case PASS:
 				{
-				State = 597;
+				State = 600;
 				Match(PASS);
-				State = 598;
+				State = 601;
 				eos();
 				}
 				break;
@@ -2375,17 +2389,17 @@ public partial class BooParser : Parser {
 			case ID:
 			case LBRACK:
 				{
-				State = 600;
+				State = 603;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				do {
 					{
 					{
-					State = 599;
+					State = 602;
 					any_intf_type_member();
 					}
 					}
-					State = 602;
+					State = 605;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & 144115188109541376L) != 0) || _la==ID || _la==LBRACK );
@@ -2394,7 +2408,7 @@ public partial class BooParser : Parser {
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 606;
+			State = 609;
 			end();
 			}
 		}
@@ -2443,35 +2457,35 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 608;
+			State = 611;
 			Match(LPAREN);
-			State = 617;
+			State = 620;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 2305843009213714432L) != 0) || ((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & 8421377L) != 0)) {
 				{
-				State = 609;
+				State = 612;
 				type_reference();
-				State = 614;
+				State = 617;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					State = 610;
+					State = 613;
 					Match(COMMA);
-					State = 611;
+					State = 614;
 					type_reference();
 					}
 					}
-					State = 616;
+					State = 619;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
 				}
 			}
 
-			State = 619;
+			State = 622;
 			Match(RPAREN);
 			}
 		}
@@ -2543,9 +2557,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 621;
+			State = 624;
 			Match(DEF);
-			State = 625;
+			State = 628;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case EVENT:
@@ -2558,49 +2572,49 @@ public partial class BooParser : Parser {
 			case YIELD:
 			case ID:
 				{
-				State = 622;
+				State = 625;
 				member();
 				}
 				break;
 			case SPLICE_BEGIN:
 				{
-				State = 623;
+				State = 626;
 				Match(SPLICE_BEGIN);
-				State = 624;
+				State = 627;
 				atom();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 636;
+			State = 639;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case LBRACK:
 				{
-				State = 627;
+				State = 630;
 				Match(LBRACK);
-				State = 629;
+				State = 632;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 628;
+					State = 631;
 					Match(OF);
 					}
 				}
 
-				State = 631;
+				State = 634;
 				generic_parameter_declaration_list();
-				State = 632;
+				State = 635;
 				Match(RBRACK);
 				}
 				break;
 			case OF:
 				{
-				State = 634;
+				State = 637;
 				Match(OF);
-				State = 635;
+				State = 638;
 				generic_parameter_declaration();
 				}
 				break;
@@ -2609,46 +2623,46 @@ public partial class BooParser : Parser {
 			default:
 				break;
 			}
-			State = 638;
+			State = 641;
 			Match(LPAREN);
-			State = 639;
+			State = 642;
 			parameter_declaration_list();
-			State = 640;
-			Match(RPAREN);
 			State = 643;
+			Match(RPAREN);
+			State = 646;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 641;
+				State = 644;
 				Match(AS);
-				State = 642;
+				State = 645;
 				type_reference();
 				}
 			}
 
-			State = 652;
+			State = 655;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case EOL:
 			case EOS:
 				{
-				State = 645;
+				State = 648;
 				eos();
-				State = 646;
+				State = 649;
 				docstring();
 				}
 				break;
 			case COLON:
 				{
-				State = 648;
+				State = 651;
 				empty_block();
-				State = 650;
+				State = 653;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==EOL || _la==EOS) {
 					{
-					State = 649;
+					State = 652;
 					eos();
 					}
 				}
@@ -2718,7 +2732,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 654;
+			State = 657;
 			_la = TokenStream.LA(1);
 			if ( !(_la==SELF || _la==ID) ) {
 			ErrorHandler.RecoverInline(this);
@@ -2727,12 +2741,12 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 659;
+			State = 662;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LPAREN || _la==LBRACK) {
 				{
-				State = 655;
+				State = 658;
 				_la = TokenStream.LA(1);
 				if ( !(_la==LPAREN || _la==LBRACK) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2741,9 +2755,9 @@ public partial class BooParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 656;
+				State = 659;
 				parameter_declaration_list();
-				State = 657;
+				State = 660;
 				_la = TokenStream.LA(1);
 				if ( !(_la==RPAREN || _la==RBRACK) ) {
 				ErrorHandler.RecoverInline(this);
@@ -2755,35 +2769,35 @@ public partial class BooParser : Parser {
 				}
 			}
 
-			State = 663;
+			State = 666;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 661;
+				State = 664;
 				Match(AS);
-				State = 662;
+				State = 665;
 				type_reference();
 				}
 			}
 
-			State = 665;
+			State = 668;
 			begin_with_doc();
-			State = 667;
+			State = 670;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			do {
 				{
 				{
-				State = 666;
+				State = 669;
 				interface_property_accessor();
 				}
 				}
-				State = 669;
+				State = 672;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			} while ( ((((_la - 32)) & ~0x3f) == 0 && ((1L << (_la - 32)) & 36028797035741185L) != 0) );
-			State = 671;
+			State = 674;
 			end();
 			}
 		}
@@ -2831,9 +2845,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 673;
+			State = 676;
 			attributes();
-			State = 674;
+			State = 677;
 			_la = TokenStream.LA(1);
 			if ( !(_la==GET || _la==SET) ) {
 			ErrorHandler.RecoverInline(this);
@@ -2842,19 +2856,19 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 677;
+			State = 680;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case EOL:
 			case EOS:
 				{
-				State = 675;
+				State = 678;
 				eos();
 				}
 				break;
 			case COLON:
 				{
-				State = 676;
+				State = 679;
 				empty_block();
 				}
 				break;
@@ -2905,13 +2919,13 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 679;
-			begin();
-			State = 680;
-			Match(PASS);
-			State = 681;
-			eos();
 			State = 682;
+			begin();
+			State = 683;
+			Match(PASS);
+			State = 684;
+			eos();
+			State = 685;
 			end();
 			}
 		}
@@ -2959,17 +2973,17 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 684;
-			Match(EVENT);
-			State = 685;
-			Match(ID);
-			State = 686;
-			Match(AS);
 			State = 687;
-			type_reference();
+			Match(EVENT);
 			State = 688;
-			eos();
+			Match(ID);
 			State = 689;
+			Match(AS);
+			State = 690;
+			type_reference();
+			State = 691;
+			eos();
+			State = 692;
 			docstring();
 			}
 		}
@@ -3021,51 +3035,51 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 691;
+			State = 694;
 			Match(ID);
-			State = 696;
+			State = 699;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,60,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,61,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 692;
+					State = 695;
 					Match(DOT);
-					State = 693;
+					State = 696;
 					Match(ID);
 					}
 					} 
 				}
-				State = 698;
+				State = 701;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,60,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,61,Context);
 			}
-			State = 706;
+			State = 709;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LBRACK) {
 				{
-				State = 699;
+				State = 702;
 				Match(LBRACK);
-				State = 701;
+				State = 704;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 700;
+					State = 703;
 					Match(OF);
 					}
 				}
 
-				State = 703;
+				State = 706;
 				type_reference_list();
-				State = 704;
+				State = 707;
 				Match(RBRACK);
 				}
 			}
 
-			State = 708;
+			State = 711;
 			Match(DOT);
 			}
 		}
@@ -3142,9 +3156,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 710;
+			State = 713;
 			Match(DEF);
-			State = 721;
+			State = 724;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case EVENT:
@@ -3158,17 +3172,17 @@ public partial class BooParser : Parser {
 			case ID:
 			case SPLICE_BEGIN:
 				{
-				State = 712;
+				State = 715;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,63,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,64,Context) ) {
 				case 1:
 					{
-					State = 711;
+					State = 714;
 					explicit_member_info();
 					}
 					break;
 				}
-				State = 717;
+				State = 720;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case EVENT:
@@ -3181,15 +3195,15 @@ public partial class BooParser : Parser {
 				case YIELD:
 				case ID:
 					{
-					State = 714;
+					State = 717;
 					member();
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 715;
+					State = 718;
 					Match(SPLICE_BEGIN);
-					State = 716;
+					State = 719;
 					atom();
 					}
 					break;
@@ -3200,68 +3214,68 @@ public partial class BooParser : Parser {
 				break;
 			case CONSTRUCTOR:
 				{
-				State = 719;
+				State = 722;
 				Match(CONSTRUCTOR);
 				}
 				break;
 			case DESTRUCTOR:
 				{
-				State = 720;
+				State = 723;
 				Match(DESTRUCTOR);
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 730;
+			State = 733;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LBRACK) {
 				{
-				State = 723;
+				State = 726;
 				Match(LBRACK);
-				State = 725;
+				State = 728;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==OF) {
 					{
-					State = 724;
+					State = 727;
 					Match(OF);
 					}
 				}
 
-				State = 727;
+				State = 730;
 				generic_parameter_declaration_list();
-				State = 728;
+				State = 731;
 				Match(RBRACK);
 				}
 			}
 
-			State = 732;
-			Match(LPAREN);
-			State = 733;
-			parameter_declaration_list();
-			State = 734;
-			Match(RPAREN);
 			State = 735;
-			attributes();
+			Match(LPAREN);
+			State = 736;
+			parameter_declaration_list();
+			State = 737;
+			Match(RPAREN);
 			State = 738;
+			attributes();
+			State = 741;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 736;
+				State = 739;
 				Match(AS);
-				State = 737;
+				State = 740;
 				type_reference();
 				}
 			}
 
-			State = 740;
+			State = 743;
 			begin_block_with_doc();
-			State = 741;
+			State = 744;
 			block();
-			State = 742;
+			State = 745;
 			end();
 			}
 		}
@@ -3341,69 +3355,69 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 70, RULE_field_or_property);
 		int _la;
 		try {
-			State = 792;
+			State = 795;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,77,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,78,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
 				{
-				State = 745;
+				State = 748;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,69,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,70,Context) ) {
 				case 1:
 					{
-					State = 744;
+					State = 747;
 					explicit_member_info();
 					}
 					break;
 				}
-				State = 751;
+				State = 754;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case ID:
 					{
-					State = 747;
+					State = 750;
 					Match(ID);
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 748;
+					State = 751;
 					Match(SPLICE_BEGIN);
-					State = 749;
+					State = 752;
 					atom();
 					}
 					break;
 				case SELF:
 					{
-					State = 750;
+					State = 753;
 					Match(SELF);
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 761;
+				State = 764;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case LPAREN:
 					{
-					State = 753;
+					State = 756;
 					Match(LPAREN);
-					State = 754;
+					State = 757;
 					parameter_declaration_list();
-					State = 755;
+					State = 758;
 					Match(RPAREN);
 					}
 					break;
 				case LBRACK:
 					{
-					State = 757;
+					State = 760;
 					Match(LBRACK);
-					State = 758;
+					State = 761;
 					parameter_declaration_list();
-					State = 759;
+					State = 762;
 					Match(RBRACK);
 					}
 					break;
@@ -3413,35 +3427,35 @@ public partial class BooParser : Parser {
 				default:
 					break;
 				}
-				State = 765;
+				State = 768;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==AS) {
 					{
-					State = 763;
+					State = 766;
 					Match(AS);
-					State = 764;
+					State = 767;
 					type_reference();
 					}
 				}
 
-				State = 767;
+				State = 770;
 				begin_with_doc();
-				State = 769;
+				State = 772;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				do {
 					{
 					{
-					State = 768;
+					State = 771;
 					property_accessor();
 					}
 					}
-					State = 771;
+					State = 774;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & -8566264232394358656L) != 0) || _la==VIRTUAL || _la==LBRACK );
-				State = 773;
+				State = 776;
 				end();
 				}
 				}
@@ -3449,7 +3463,7 @@ public partial class BooParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 775;
+				State = 778;
 				member_macro();
 				}
 				break;
@@ -3457,60 +3471,60 @@ public partial class BooParser : Parser {
 				EnterOuterAlt(_localctx, 3);
 				{
 				{
-				State = 779;
+				State = 782;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case ID:
 					{
-					State = 776;
+					State = 779;
 					Match(ID);
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 777;
+					State = 780;
 					Match(SPLICE_BEGIN);
-					State = 778;
+					State = 781;
 					atom();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 783;
+				State = 786;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==AS) {
 					{
-					State = 781;
+					State = 784;
 					Match(AS);
-					State = 782;
+					State = 785;
 					type_reference();
 					}
 				}
 
-				State = 788;
+				State = 791;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case ASSIGN:
 					{
-					State = 785;
+					State = 788;
 					Match(ASSIGN);
-					State = 786;
+					State = 789;
 					declaration_initializer();
 					}
 					break;
 				case EOL:
 				case EOS:
 					{
-					State = 787;
+					State = 790;
 					eos();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 790;
+				State = 793;
 				docstring();
 				}
 				}
@@ -3552,7 +3566,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 794;
+			State = 797;
 			macro_stmt();
 			}
 		}
@@ -3601,31 +3615,31 @@ public partial class BooParser : Parser {
 		Declaration_initializerContext _localctx = new Declaration_initializerContext(Context, State);
 		EnterRule(_localctx, 74, RULE_declaration_initializer);
 		try {
-			State = 803;
+			State = 806;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,78,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,79,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 796;
+				State = 799;
 				slicing_expression();
-				State = 797;
+				State = 800;
 				method_invocation_block();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 799;
+				State = 802;
 				array_or_expression();
-				State = 800;
+				State = 803;
 				eos();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 802;
+				State = 805;
 				callable_expression();
 				}
 				break;
@@ -3667,20 +3681,20 @@ public partial class BooParser : Parser {
 		Simple_initializerContext _localctx = new Simple_initializerContext(Context, State);
 		EnterRule(_localctx, 76, RULE_simple_initializer);
 		try {
-			State = 807;
+			State = 810;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,79,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,80,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 805;
+				State = 808;
 				array_or_expression();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 806;
+				State = 809;
 				callable_expression();
 				}
 				break;
@@ -3733,11 +3747,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 809;
+			State = 812;
 			attributes();
-			State = 810;
+			State = 813;
 			modifiers();
-			State = 811;
+			State = 814;
 			_la = TokenStream.LA(1);
 			if ( !(_la==GET || _la==SET) ) {
 			ErrorHandler.RecoverInline(this);
@@ -3746,19 +3760,19 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 814;
+			State = 817;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case EOL:
 			case EOS:
 				{
-				State = 812;
+				State = 815;
 				eos();
 				}
 				break;
 			case COLON:
 				{
-				State = 813;
+				State = 816;
 				compound_stmt();
 				}
 				break;
@@ -3809,31 +3823,31 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 817;
+			State = 820;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,81,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,82,Context) ) {
 			case 1:
 				{
-				State = 816;
+				State = 819;
 				eos();
 				}
 				break;
 			}
-			State = 822;
+			State = 825;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,82,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,83,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 819;
+					State = 822;
 					stmt_or_nested_function();
 					}
 					} 
 				}
-				State = 824;
+				State = 827;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,82,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,83,Context);
 			}
 			}
 		}
@@ -3879,17 +3893,17 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 826;
+			State = 829;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,83,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,84,Context) ) {
 			case 1:
 				{
-				State = 825;
+				State = 828;
 				eos();
 				}
 				break;
 			}
-			State = 829;
+			State = 832;
 			ErrorHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -3897,7 +3911,7 @@ public partial class BooParser : Parser {
 				case 1:
 					{
 					{
-					State = 828;
+					State = 831;
 					stmt_or_nested_function();
 					}
 					}
@@ -3905,9 +3919,9 @@ public partial class BooParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 831;
+				State = 834;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,84,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,85,Context);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER );
 			}
 		}
@@ -3950,17 +3964,17 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 836;
+			State = 839;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & 1229549803380146177L) != 0)) {
 				{
 				{
-				State = 833;
+				State = 836;
 				type_member_modifier();
 				}
 				}
-				State = 838;
+				State = 841;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -4011,7 +4025,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 839;
+			State = 842;
 			_la = TokenStream.LA(1);
 			if ( !(((((_la - 7)) & ~0x3f) == 0 && ((1L << (_la - 7)) & 1229549803380146177L) != 0)) ) {
 			ErrorHandler.RecoverInline(this);
@@ -4055,7 +4069,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 841;
+			State = 844;
 			Match(REF);
 			}
 		}
@@ -4102,26 +4116,26 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 851;
+			State = 854;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (((((_la - 54)) & ~0x3f) == 0 && ((1L << (_la - 54)) & 141295834169345L) != 0)) {
 				{
-				State = 843;
+				State = 846;
 				parameter_declaration();
-				State = 848;
+				State = 851;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					State = 844;
+					State = 847;
 					Match(COMMA);
-					State = 845;
+					State = 848;
 					parameter_declaration();
 					}
 					}
-					State = 850;
+					State = 853;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
@@ -4182,43 +4196,43 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 853;
+			State = 856;
 			attributes();
-			State = 876;
+			State = 879;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case MULTIPLY:
 				{
-				State = 854;
+				State = 857;
 				Match(MULTIPLY);
-				State = 858;
+				State = 861;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case ID:
 					{
-					State = 855;
+					State = 858;
 					Match(ID);
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 856;
+					State = 859;
 					Match(SPLICE_BEGIN);
-					State = 857;
+					State = 860;
 					atom();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 862;
+				State = 865;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==AS) {
 					{
-					State = 860;
+					State = 863;
 					Match(AS);
-					State = 861;
+					State = 864;
 					array_type_reference();
 					}
 				}
@@ -4229,44 +4243,44 @@ public partial class BooParser : Parser {
 			case ID:
 			case SPLICE_BEGIN:
 				{
-				State = 865;
+				State = 868;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==REF) {
 					{
-					State = 864;
+					State = 867;
 					parameter_modifier();
 					}
 				}
 
-				State = 870;
+				State = 873;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case ID:
 					{
-					State = 867;
+					State = 870;
 					Match(ID);
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 868;
+					State = 871;
 					Match(SPLICE_BEGIN);
-					State = 869;
+					State = 872;
 					atom();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 874;
+				State = 877;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==AS) {
 					{
-					State = 872;
+					State = 875;
 					Match(AS);
-					State = 873;
+					State = 876;
 					type_reference();
 					}
 				}
@@ -4321,26 +4335,26 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 886;
+			State = 889;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if ((((_la) & ~0x3f) == 0 && ((1L << _la) & 2323857407723196416L) != 0) || ((((_la - 70)) & ~0x3f) == 0 && ((1L << (_la - 70)) & 2155905025L) != 0)) {
 				{
-				State = 878;
+				State = 881;
 				callable_parameter_declaration();
-				State = 883;
+				State = 886;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					State = 879;
+					State = 882;
 					Match(COMMA);
-					State = 880;
+					State = 883;
 					callable_parameter_declaration();
 					}
 					}
-					State = 885;
+					State = 888;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
@@ -4387,15 +4401,15 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 96, RULE_callable_parameter_declaration);
 		int _la;
 		try {
-			State = 894;
+			State = 897;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case MULTIPLY:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 888;
+				State = 891;
 				Match(MULTIPLY);
-				State = 889;
+				State = 892;
 				type_reference();
 				}
 				break;
@@ -4408,17 +4422,17 @@ public partial class BooParser : Parser {
 			case SPLICE_BEGIN:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 891;
+				State = 894;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==REF) {
 					{
-					State = 890;
+					State = 893;
 					parameter_modifier();
 					}
 				}
 
-				State = 893;
+				State = 896;
 				type_reference();
 				}
 				break;
@@ -4469,21 +4483,21 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 896;
+			State = 899;
 			generic_parameter_declaration();
-			State = 901;
+			State = 904;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 897;
+				State = 900;
 				Match(COMMA);
-				State = 898;
+				State = 901;
 				generic_parameter_declaration();
 				}
 				}
-				State = 903;
+				State = 906;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -4527,18 +4541,18 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 904;
+			State = 907;
 			Match(ID);
-			State = 909;
+			State = 912;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,99,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,100,Context) ) {
 			case 1:
 				{
-				State = 905;
+				State = 908;
 				Match(LPAREN);
-				State = 906;
+				State = 909;
 				generic_parameter_constraints();
-				State = 907;
+				State = 910;
 				Match(RPAREN);
 				}
 				break;
@@ -4588,24 +4602,24 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 915;
+			State = 918;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case CLASS:
 				{
-				State = 911;
+				State = 914;
 				Match(CLASS);
 				}
 				break;
 			case STRUCT:
 				{
-				State = 912;
+				State = 915;
 				Match(STRUCT);
 				}
 				break;
 			case CONSTRUCTOR:
 				{
-				State = 913;
+				State = 916;
 				Match(CONSTRUCTOR);
 				}
 				break;
@@ -4616,21 +4630,21 @@ public partial class BooParser : Parser {
 			case LPAREN:
 			case SPLICE_BEGIN:
 				{
-				State = 914;
+				State = 917;
 				type_reference();
 				}
 				break;
 			default:
 				throw new NoViableAltException(this);
 			}
-			State = 919;
+			State = 922;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==COMMA) {
 				{
-				State = 917;
+				State = 920;
 				Match(COMMA);
-				State = 918;
+				State = 921;
 				generic_parameter_constraints();
 				}
 			}
@@ -4679,22 +4693,22 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 921;
-			Match(CALLABLE);
-			State = 922;
-			Match(LPAREN);
-			State = 923;
-			callable_parameter_declaration_list();
 			State = 924;
-			Match(RPAREN);
+			Match(CALLABLE);
+			State = 925;
+			Match(LPAREN);
+			State = 926;
+			callable_parameter_declaration_list();
 			State = 927;
+			Match(RPAREN);
+			State = 930;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,102,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,103,Context) ) {
 			case 1:
 				{
-				State = 925;
+				State = 928;
 				Match(AS);
-				State = 926;
+				State = 929;
 				type_reference();
 				}
 				break;
@@ -4743,23 +4757,23 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 929;
+			State = 932;
 			Match(LPAREN);
-			State = 930;
-			type_reference();
 			State = 933;
+			type_reference();
+			State = 936;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==COMMA) {
 				{
-				State = 931;
+				State = 934;
 				Match(COMMA);
-				State = 932;
+				State = 935;
 				integer_literal();
 				}
 			}
 
-			State = 935;
+			State = 938;
 			Match(RPAREN);
 			}
 		}
@@ -4806,21 +4820,21 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 937;
+			State = 940;
 			type_reference();
-			State = 942;
+			State = 945;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 938;
+				State = 941;
 				Match(COMMA);
-				State = 939;
+				State = 942;
 				type_reference();
 				}
 				}
-				State = 944;
+				State = 947;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -4862,9 +4876,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 945;
+			State = 948;
 			Match(SPLICE_BEGIN);
-			State = 946;
+			State = 949;
 			atom();
 			}
 		}
@@ -4934,72 +4948,72 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 980;
+			State = 983;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,110,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,111,Context) ) {
 			case 1:
 				{
-				State = 948;
+				State = 951;
 				splice_type_reference();
 				}
 				break;
 			case 2:
 				{
-				State = 949;
+				State = 952;
 				array_type_reference();
 				}
 				break;
 			case 3:
 				{
-				State = 950;
+				State = 953;
 				callable_type_reference();
 				}
 				break;
 			case 4:
 				{
-				State = 951;
+				State = 954;
 				type_name();
-				State = 975;
+				State = 978;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,108,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,109,Context) ) {
 				case 1:
 					{
-					State = 952;
+					State = 955;
 					Match(LBRACK);
-					State = 954;
+					State = 957;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==OF) {
 						{
-						State = 953;
+						State = 956;
 						Match(OF);
 						}
 					}
 
-					State = 968;
+					State = 971;
 					ErrorHandler.Sync(this);
 					switch (TokenStream.LA(1)) {
 					case MULTIPLY:
 						{
-						State = 956;
+						State = 959;
 						Match(MULTIPLY);
-						State = 961;
+						State = 964;
 						ErrorHandler.Sync(this);
 						_la = TokenStream.LA(1);
 						while (_la==COMMA) {
 							{
 							{
-							State = 957;
+							State = 960;
 							Match(COMMA);
-							State = 958;
+							State = 961;
 							Match(MULTIPLY);
 							}
 							}
-							State = 963;
+							State = 966;
 							ErrorHandler.Sync(this);
 							_la = TokenStream.LA(1);
 						}
-						State = 964;
+						State = 967;
 						Match(RBRACK);
 						}
 						break;
@@ -5010,9 +5024,9 @@ public partial class BooParser : Parser {
 					case LPAREN:
 					case SPLICE_BEGIN:
 						{
-						State = 965;
+						State = 968;
 						type_reference_list();
-						State = 966;
+						State = 969;
 						Match(RBRACK);
 						}
 						break;
@@ -5023,17 +5037,17 @@ public partial class BooParser : Parser {
 					break;
 				case 2:
 					{
-					State = 970;
+					State = 973;
 					Match(OF);
-					State = 971;
+					State = 974;
 					Match(MULTIPLY);
 					}
 					break;
 				case 3:
 					{
-					State = 972;
+					State = 975;
 					Match(OF);
-					State = 973;
+					State = 976;
 					type_reference();
 					}
 					break;
@@ -5042,12 +5056,12 @@ public partial class BooParser : Parser {
 					}
 					break;
 				}
-				State = 978;
+				State = 981;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,109,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,110,Context) ) {
 				case 1:
 					{
-					State = 977;
+					State = 980;
 					Match(NULLABLE_SUFFIX);
 					}
 					break;
@@ -5055,7 +5069,7 @@ public partial class BooParser : Parser {
 				}
 				break;
 			}
-			State = 982;
+			State = 985;
 			type_degree();
 			}
 		}
@@ -5101,14 +5115,14 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 987;
+			State = 990;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,111,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,112,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 984;
+					State = 987;
 					_la = TokenStream.LA(1);
 					if ( !(_la==MULTIPLY || _la==EXPONENTIATION) ) {
 					ErrorHandler.RecoverInline(this);
@@ -5120,9 +5134,9 @@ public partial class BooParser : Parser {
 					}
 					} 
 				}
-				State = 989;
+				State = 992;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,111,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,112,Context);
 			}
 			}
 		}
@@ -5161,28 +5175,28 @@ public partial class BooParser : Parser {
 		Type_nameContext _localctx = new Type_nameContext(Context, State);
 		EnterRule(_localctx, 116, RULE_type_name);
 		try {
-			State = 993;
+			State = 996;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case THEN:
 			case ID:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 990;
+				State = 993;
 				identifier();
 				}
 				break;
 			case CALLABLE:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 991;
+				State = 994;
 				Match(CALLABLE);
 				}
 				break;
 			case CHAR:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 992;
+				State = 995;
 				Match(CHAR);
 				}
 				break;
@@ -5224,9 +5238,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 995;
+			State = 998;
 			Match(COLON);
-			State = 996;
+			State = 999;
 			Match(INDENT);
 			}
 		}
@@ -5276,23 +5290,23 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 998;
+			State = 1001;
 			Match(COLON);
-			State = 1002;
+			State = 1005;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==EOL || _la==EOS) {
 				{
-				State = 999;
+				State = 1002;
 				eos();
-				State = 1000;
+				State = 1003;
 				_localctx.outer = docstring();
 				}
 			}
 
-			State = 1004;
+			State = 1007;
 			Match(INDENT);
-			State = 1005;
+			State = 1008;
 			_localctx.inner = docstring();
 			}
 		}
@@ -5342,23 +5356,23 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1007;
+			State = 1010;
 			Match(COLON);
-			State = 1011;
+			State = 1014;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==EOL || _la==EOS) {
 				{
-				State = 1008;
+				State = 1011;
 				eos();
-				State = 1009;
+				State = 1012;
 				_localctx.outer = docstring();
 				}
 			}
 
-			State = 1013;
+			State = 1016;
 			Match(INDENT);
-			State = 1014;
+			State = 1017;
 			_localctx.inner = docstring();
 			}
 		}
@@ -5398,14 +5412,14 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1016;
+			State = 1019;
 			Match(DEDENT);
-			State = 1018;
+			State = 1021;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,115,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,116,Context) ) {
 			case 1:
 				{
-				State = 1017;
+				State = 1020;
 				eos();
 				}
 				break;
@@ -5453,26 +5467,26 @@ public partial class BooParser : Parser {
 		Compound_stmtContext _localctx = new Compound_stmtContext(Context, State);
 		EnterRule(_localctx, 126, RULE_compound_stmt);
 		try {
-			State = 1026;
+			State = 1029;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,116,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,117,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1020;
+				State = 1023;
 				single_line_block();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1021;
-				Match(COLON);
-				State = 1022;
-				Match(INDENT);
-				State = 1023;
-				block();
 				State = 1024;
+				Match(COLON);
+				State = 1025;
+				Match(INDENT);
+				State = 1026;
+				block();
+				State = 1027;
 				end();
 				}
 				break;
@@ -5527,35 +5541,35 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1028;
+			State = 1031;
 			Match(COLON);
-			State = 1029;
+			State = 1032;
 			simple_stmt();
-			State = 1036;
+			State = 1039;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==EOS) {
 				{
 				{
-				State = 1030;
+				State = 1033;
 				Match(EOS);
-				State = 1032;
+				State = 1035;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,117,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,118,Context) ) {
 				case 1:
 					{
-					State = 1031;
+					State = 1034;
 					simple_stmt();
 					}
 					break;
 				}
 				}
 				}
-				State = 1038;
+				State = 1041;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
-			State = 1040;
+			State = 1043;
 			ErrorHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -5563,7 +5577,7 @@ public partial class BooParser : Parser {
 				case 1:
 					{
 					{
-					State = 1039;
+					State = 1042;
 					Match(EOL);
 					}
 					}
@@ -5571,9 +5585,9 @@ public partial class BooParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1042;
+				State = 1045;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,119,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,120,Context);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER );
 			}
 		}
@@ -5615,9 +5629,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1044;
+			State = 1047;
 			macro_name();
-			State = 1045;
+			State = 1048;
 			expression_list();
 			}
 		}
@@ -5659,18 +5673,18 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1049;
+			State = 1052;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,120,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,121,Context) ) {
 			case 1:
 				{
-				State = 1047;
+				State = 1050;
 				stmt_or_nested_function();
 				}
 				break;
 			case 2:
 				{
-				State = 1048;
+				State = 1051;
 				type_member_stmt();
 				}
 				break;
@@ -5719,17 +5733,17 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1052;
+			State = 1055;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,121,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,122,Context) ) {
 			case 1:
 				{
-				State = 1051;
+				State = 1054;
 				eos();
 				}
 				break;
 			}
-			State = 1055;
+			State = 1058;
 			ErrorHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -5737,7 +5751,7 @@ public partial class BooParser : Parser {
 				case 1:
 					{
 					{
-					State = 1054;
+					State = 1057;
 					any_macro_stmt();
 					}
 					}
@@ -5745,9 +5759,9 @@ public partial class BooParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1057;
+				State = 1060;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,122,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,123,Context);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER );
 			}
 		}
@@ -5786,7 +5800,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1059;
+			State = 1062;
 			type_definition_member();
 			}
 		}
@@ -5831,26 +5845,26 @@ public partial class BooParser : Parser {
 		Macro_compound_stmtContext _localctx = new Macro_compound_stmtContext(Context, State);
 		EnterRule(_localctx, 138, RULE_macro_compound_stmt);
 		try {
-			State = 1067;
+			State = 1070;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,123,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,124,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1061;
+				State = 1064;
 				single_line_block();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1062;
-				Match(COLON);
-				State = 1063;
-				Match(INDENT);
-				State = 1064;
-				macro_block();
 				State = 1065;
+				Match(COLON);
+				State = 1066;
+				Match(INDENT);
+				State = 1067;
+				macro_block();
+				State = 1068;
 				end();
 				}
 				break;
@@ -5915,38 +5929,38 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1069;
+			State = 1072;
 			macro_name();
-			State = 1070;
+			State = 1073;
 			expression_list();
-			State = 1084;
+			State = 1087;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,125,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,126,Context) ) {
 			case 1:
 				{
-				State = 1071;
+				State = 1074;
 				begin_with_doc();
-				State = 1072;
+				State = 1075;
 				macro_block();
-				State = 1073;
+				State = 1076;
 				end();
 				}
 				break;
 			case 2:
 				{
-				State = 1075;
+				State = 1078;
 				macro_compound_stmt();
 				}
 				break;
 			case 3:
 				{
-				State = 1080;
+				State = 1083;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case EOL:
 				case EOS:
 					{
-					State = 1076;
+					State = 1079;
 					eos();
 					}
 					break;
@@ -5954,16 +5968,16 @@ public partial class BooParser : Parser {
 				case UNLESS:
 				case WHILE:
 					{
-					State = 1077;
+					State = 1080;
 					stmt_modifier();
-					State = 1078;
+					State = 1081;
 					eos();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1082;
+				State = 1085;
 				docstring();
 				}
 				break;
@@ -6005,7 +6019,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1086;
+			State = 1089;
 			_la = TokenStream.LA(1);
 			if ( !(_la==THEN || _la==ID) ) {
 			ErrorHandler.RecoverInline(this);
@@ -6049,7 +6063,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1088;
+			State = 1091;
 			Match(PASS);
 			}
 		}
@@ -6087,9 +6101,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1090;
+			State = 1093;
 			Match(GOTO);
-			State = 1091;
+			State = 1094;
 			Match(ID);
 			}
 		}
@@ -6127,9 +6141,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1093;
+			State = 1096;
 			Match(COLON);
-			State = 1094;
+			State = 1097;
 			Match(ID);
 			}
 		}
@@ -6180,29 +6194,29 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1096;
+			State = 1099;
 			Match(DEF);
-			State = 1097;
+			State = 1100;
 			Match(ID);
-			State = 1105;
+			State = 1108;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==LPAREN) {
 				{
-				State = 1098;
+				State = 1101;
 				Match(LPAREN);
-				State = 1099;
+				State = 1102;
 				parameter_declaration_list();
-				State = 1100;
-				Match(RPAREN);
 				State = 1103;
+				Match(RPAREN);
+				State = 1106;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==AS) {
 					{
-					State = 1101;
+					State = 1104;
 					Match(AS);
-					State = 1102;
+					State = 1105;
 					type_reference();
 					}
 				}
@@ -6210,7 +6224,7 @@ public partial class BooParser : Parser {
 				}
 			}
 
-			State = 1107;
+			State = 1110;
 			compound_stmt();
 			}
 		}
@@ -6250,20 +6264,20 @@ public partial class BooParser : Parser {
 		Stmt_or_nested_functionContext _localctx = new Stmt_or_nested_functionContext(Context, State);
 		EnterRule(_localctx, 152, RULE_stmt_or_nested_function);
 		try {
-			State = 1111;
+			State = 1114;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,128,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,129,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1109;
+				State = 1112;
 				nested_function();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1110;
+				State = 1113;
 				stmt();
 				}
 				break;
@@ -6360,150 +6374,150 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 154, RULE_stmt);
 		int _la;
 		try {
-			State = 1141;
+			State = 1144;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,131,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,132,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1113;
+				State = 1116;
 				for_stmt();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1114;
+				State = 1117;
 				while_stmt();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1115;
+				State = 1118;
 				if_stmt();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 1116;
+				State = 1119;
 				unless_stmt();
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 1117;
+				State = 1120;
 				try_stmt();
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 1118;
+				State = 1121;
 				if (!(IsValidMacroArgument(InputStream.LA(2)))) throw new FailedPredicateException(this, "IsValidMacroArgument(InputStream.LA(2))");
-				State = 1119;
+				State = 1122;
 				macro_stmt();
 				}
 				break;
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 1120;
+				State = 1123;
 				assignment_or_method_invocation_with_block_stmt();
 				}
 				break;
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 1121;
+				State = 1124;
 				return_stmt();
 				}
 				break;
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 1122;
+				State = 1125;
 				unpack_stmt();
 				}
 				break;
 			case 10:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 1123;
+				State = 1126;
 				declaration_stmt();
 				}
 				break;
 			case 11:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 1124;
+				State = 1127;
 				pass_stmt();
-				State = 1125;
+				State = 1128;
 				eos();
 				}
 				break;
 			case 12:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 1134;
+				State = 1137;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,129,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,130,Context) ) {
 				case 1:
 					{
-					State = 1127;
+					State = 1130;
 					goto_stmt();
 					}
 					break;
 				case 2:
 					{
-					State = 1128;
+					State = 1131;
 					label_stmt();
 					}
 					break;
 				case 3:
 					{
-					State = 1129;
+					State = 1132;
 					yield_stmt();
 					}
 					break;
 				case 4:
 					{
-					State = 1130;
+					State = 1133;
 					break_stmt();
 					}
 					break;
 				case 5:
 					{
-					State = 1131;
+					State = 1134;
 					continue_stmt();
 					}
 					break;
 				case 6:
 					{
-					State = 1132;
+					State = 1135;
 					raise_stmt();
 					}
 					break;
 				case 7:
 					{
-					State = 1133;
+					State = 1136;
 					expression_stmt();
 					}
 					break;
 				}
-				State = 1137;
+				State = 1140;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 					{
-					State = 1136;
+					State = 1139;
 					stmt_modifier();
 					}
 				}
 
-				State = 1139;
+				State = 1142;
 				eos();
 				}
 				break;
@@ -6578,98 +6592,98 @@ public partial class BooParser : Parser {
 		Simple_stmtContext _localctx = new Simple_stmtContext(Context, State);
 		EnterRule(_localctx, 156, RULE_simple_stmt);
 		try {
-			State = 1159;
+			State = 1162;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,133,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,134,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1143;
+				State = 1146;
 				if (!(IsValidMacroArgument(InputStream.LA(2)))) throw new FailedPredicateException(this, "IsValidMacroArgument(InputStream.LA(2))");
-				State = 1144;
+				State = 1147;
 				closure_macro_stmt();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1145;
+				State = 1148;
 				assignment_or_method_invocation();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1146;
+				State = 1149;
 				return_expression_stmt();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 1147;
+				State = 1150;
 				unpack();
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 1148;
+				State = 1151;
 				declaration_stmt();
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 1149;
+				State = 1152;
 				pass_stmt();
 				}
 				break;
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 1157;
+				State = 1160;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,132,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,133,Context) ) {
 				case 1:
 					{
-					State = 1150;
+					State = 1153;
 					goto_stmt();
 					}
 					break;
 				case 2:
 					{
-					State = 1151;
+					State = 1154;
 					label_stmt();
 					}
 					break;
 				case 3:
 					{
-					State = 1152;
+					State = 1155;
 					yield_stmt();
 					}
 					break;
 				case 4:
 					{
-					State = 1153;
+					State = 1156;
 					break_stmt();
 					}
 					break;
 				case 5:
 					{
-					State = 1154;
+					State = 1157;
 					continue_stmt();
 					}
 					break;
 				case 6:
 					{
-					State = 1155;
+					State = 1158;
 					raise_stmt();
 					}
 					break;
 				case 7:
 					{
-					State = 1156;
+					State = 1159;
 					expression_stmt();
 					}
 					break;
@@ -6717,7 +6731,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1161;
+			State = 1164;
 			_la = TokenStream.LA(1);
 			if ( !(((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) ) {
 			ErrorHandler.RecoverInline(this);
@@ -6726,7 +6740,7 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 1162;
+			State = 1165;
 			boolean_expression();
 			}
 		}
@@ -6766,20 +6780,20 @@ public partial class BooParser : Parser {
 		Callable_or_expressionContext _localctx = new Callable_or_expressionContext(Context, State);
 		EnterRule(_localctx, 160, RULE_callable_or_expression);
 		try {
-			State = 1166;
+			State = 1169;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,134,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,135,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1164;
+				State = 1167;
 				callable_expression();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1165;
+				State = 1168;
 				array_or_expression();
 				}
 				break;
@@ -6837,61 +6851,61 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 162, RULE_internal_closure_stmt);
 		int _la;
 		try {
-			State = 1180;
+			State = 1183;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,137,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,138,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1168;
+				State = 1171;
 				return_expression_stmt();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1175;
+				State = 1178;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,135,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,136,Context) ) {
 				case 1:
 					{
-					State = 1169;
+					State = 1172;
 					unpack();
 					}
 					break;
 				case 2:
 					{
-					State = 1170;
+					State = 1173;
 					if (!(IsValidClosureMacroArgument(InputStream.LA(2)))) throw new FailedPredicateException(this, "IsValidClosureMacroArgument(InputStream.LA(2))");
-					State = 1171;
+					State = 1174;
 					closure_macro_stmt();
 					}
 					break;
 				case 3:
 					{
-					State = 1172;
+					State = 1175;
 					closure_expression_stmt();
 					}
 					break;
 				case 4:
 					{
-					State = 1173;
+					State = 1176;
 					raise_stmt();
 					}
 					break;
 				case 5:
 					{
-					State = 1174;
+					State = 1177;
 					yield_stmt();
 					}
 					break;
 				}
-				State = 1178;
+				State = 1181;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 					{
-					State = 1177;
+					State = 1180;
 					stmt_modifier();
 					}
 				}
@@ -6935,7 +6949,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1182;
+			State = 1185;
 			array_or_expression();
 			}
 		}
@@ -6990,47 +7004,47 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1184;
+			State = 1187;
 			Match(LBRACE);
-			State = 1188;
+			State = 1191;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,138,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,139,Context) ) {
 			case 1:
 				{
-				State = 1185;
+				State = 1188;
 				parameter_declaration_list();
-				State = 1186;
+				State = 1189;
 				Match(BITWISE_OR);
 				}
 				break;
 			}
-			State = 1190;
+			State = 1193;
 			internal_closure_stmt();
-			State = 1197;
+			State = 1200;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==EOL || _la==EOS) {
 				{
 				{
-				State = 1191;
+				State = 1194;
 				eos();
-				State = 1193;
+				State = 1196;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,139,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,140,Context) ) {
 				case 1:
 					{
-					State = 1192;
+					State = 1195;
 					internal_closure_stmt();
 					}
 					break;
 				}
 				}
 				}
-				State = 1199;
+				State = 1202;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
-			State = 1200;
+			State = 1203;
 			Match(RBRACE);
 			}
 		}
@@ -7079,13 +7093,13 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 168, RULE_callable_expression);
 		int _la;
 		try {
-			State = 1214;
+			State = 1217;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case COLON:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1202;
+				State = 1205;
 				compound_stmt();
 				}
 				break;
@@ -7093,7 +7107,7 @@ public partial class BooParser : Parser {
 			case DO:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1203;
+				State = 1206;
 				_la = TokenStream.LA(1);
 				if ( !(_la==DEF || _la==DO) ) {
 				ErrorHandler.RecoverInline(this);
@@ -7102,25 +7116,25 @@ public partial class BooParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 1211;
+				State = 1214;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==LPAREN) {
 					{
-					State = 1204;
+					State = 1207;
 					Match(LPAREN);
-					State = 1205;
+					State = 1208;
 					parameter_declaration_list();
-					State = 1206;
-					Match(RPAREN);
 					State = 1209;
+					Match(RPAREN);
+					State = 1212;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==AS) {
 						{
-						State = 1207;
+						State = 1210;
 						Match(AS);
-						State = 1208;
+						State = 1211;
 						type_reference();
 						}
 					}
@@ -7128,7 +7142,7 @@ public partial class BooParser : Parser {
 					}
 				}
 
-				State = 1213;
+				State = 1216;
 				compound_stmt();
 				}
 				break;
@@ -7184,46 +7198,46 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1216;
+			State = 1219;
 			Match(TRY);
-			State = 1217;
+			State = 1220;
 			compound_stmt();
-			State = 1221;
+			State = 1224;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,144,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,145,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1218;
+					State = 1221;
 					exception_handler();
 					}
 					} 
 				}
-				State = 1223;
+				State = 1226;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,144,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,145,Context);
 			}
-			State = 1226;
-			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,145,Context) ) {
-			case 1:
-				{
-				State = 1224;
-				Match(FAILURE);
-				State = 1225;
-				compound_stmt();
-				}
-				break;
-			}
-			State = 1230;
+			State = 1229;
 			ErrorHandler.Sync(this);
 			switch ( Interpreter.AdaptivePredict(TokenStream,146,Context) ) {
 			case 1:
 				{
+				State = 1227;
+				Match(FAILURE);
 				State = 1228;
+				compound_stmt();
+				}
+				break;
+			}
+			State = 1233;
+			ErrorHandler.Sync(this);
+			switch ( Interpreter.AdaptivePredict(TokenStream,147,Context) ) {
+			case 1:
+				{
+				State = 1231;
 				Match(ENSURE);
-				State = 1229;
+				State = 1232;
 				compound_stmt();
 				}
 				break;
@@ -7277,36 +7291,36 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1232;
+			State = 1235;
 			Match(EXCEPT);
-			State = 1234;
+			State = 1237;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==ID) {
 				{
-				State = 1233;
+				State = 1236;
 				Match(ID);
 				}
 			}
 
-			State = 1238;
+			State = 1241;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 1236;
+				State = 1239;
 				Match(AS);
-				State = 1237;
+				State = 1240;
 				type_reference();
 				}
 			}
 
-			State = 1242;
+			State = 1245;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==IF || _la==UNLESS) {
 				{
-				State = 1240;
+				State = 1243;
 				_la = TokenStream.LA(1);
 				if ( !(_la==IF || _la==UNLESS) ) {
 				ErrorHandler.RecoverInline(this);
@@ -7315,12 +7329,12 @@ public partial class BooParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 1241;
+				State = 1244;
 				boolean_expression();
 				}
 			}
 
-			State = 1244;
+			State = 1247;
 			compound_stmt();
 			}
 		}
@@ -7360,14 +7374,14 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1246;
+			State = 1249;
 			Match(RAISE);
-			State = 1248;
+			State = 1251;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,150,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,151,Context) ) {
 			case 1:
 				{
-				State = 1247;
+				State = 1250;
 				expression();
 				}
 				break;
@@ -7425,31 +7439,31 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1250;
+			State = 1253;
 			Match(ID);
-			State = 1251;
+			State = 1254;
 			Match(AS);
-			State = 1252;
+			State = 1255;
 			type_reference();
-			State = 1262;
+			State = 1265;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ASSIGN:
 				{
-				State = 1253;
-				Match(ASSIGN);
 				State = 1256;
+				Match(ASSIGN);
+				State = 1259;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,151,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,152,Context) ) {
 				case 1:
 					{
-					State = 1254;
+					State = 1257;
 					declaration_initializer();
 					}
 					break;
 				case 2:
 					{
-					State = 1255;
+					State = 1258;
 					simple_initializer();
 					}
 					break;
@@ -7462,17 +7476,17 @@ public partial class BooParser : Parser {
 			case WHILE:
 			case EOS:
 				{
-				State = 1259;
+				State = 1262;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 					{
-					State = 1258;
+					State = 1261;
 					stmt_modifier();
 					}
 				}
 
-				State = 1261;
+				State = 1264;
 				eos();
 				}
 				break;
@@ -7516,7 +7530,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1264;
+			State = 1267;
 			assignment_expression();
 			}
 		}
@@ -7560,24 +7574,24 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1266;
+			State = 1269;
 			Match(RETURN);
-			State = 1268;
+			State = 1271;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,154,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,155,Context) ) {
 			case 1:
 				{
-				State = 1267;
+				State = 1270;
 				array_or_expression();
 				}
 				break;
 			}
-			State = 1271;
+			State = 1274;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 				{
-				State = 1270;
+				State = 1273;
 				stmt_modifier();
 				}
 			}
@@ -7633,23 +7647,23 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1273;
+			State = 1276;
 			Match(RETURN);
-			State = 1287;
+			State = 1290;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,159,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,160,Context) ) {
 			case 1:
 				{
-				State = 1274;
+				State = 1277;
 				array_or_expression();
-				State = 1280;
+				State = 1283;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case DEF:
 				case DO:
 				case COLON:
 					{
-					State = 1275;
+					State = 1278;
 					method_invocation_block();
 					}
 					break;
@@ -7659,17 +7673,17 @@ public partial class BooParser : Parser {
 				case WHILE:
 				case EOS:
 					{
-					State = 1277;
+					State = 1280;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 						{
-						State = 1276;
+						State = 1279;
 						stmt_modifier();
 						}
 					}
 
-					State = 1279;
+					State = 1282;
 					eos();
 					}
 					break;
@@ -7680,23 +7694,23 @@ public partial class BooParser : Parser {
 				break;
 			case 2:
 				{
-				State = 1282;
+				State = 1285;
 				callable_expression();
 				}
 				break;
 			case 3:
 				{
-				State = 1284;
+				State = 1287;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 					{
-					State = 1283;
+					State = 1286;
 					stmt_modifier();
 					}
 				}
 
-				State = 1286;
+				State = 1289;
 				eos();
 				}
 				break;
@@ -7739,14 +7753,14 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1289;
+			State = 1292;
 			Match(YIELD);
-			State = 1291;
+			State = 1294;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,160,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,161,Context) ) {
 			case 1:
 				{
-				State = 1290;
+				State = 1293;
 				array_or_expression();
 				}
 				break;
@@ -7786,7 +7800,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1293;
+			State = 1296;
 			Match(BREAK);
 			}
 		}
@@ -7823,7 +7837,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1295;
+			State = 1298;
 			Match(CONTINUE);
 			}
 		}
@@ -7866,11 +7880,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1297;
+			State = 1300;
 			Match(UNLESS);
-			State = 1298;
+			State = 1301;
 			expression();
-			State = 1299;
+			State = 1302;
 			compound_stmt();
 			}
 		}
@@ -7922,36 +7936,36 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1301;
-			Match(FOR);
-			State = 1302;
-			declaration_list();
-			State = 1303;
-			Match(IN);
 			State = 1304;
-			array_or_expression();
+			Match(FOR);
 			State = 1305;
-			compound_stmt();
+			declaration_list();
+			State = 1306;
+			Match(IN);
+			State = 1307;
+			array_or_expression();
 			State = 1308;
-			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,161,Context) ) {
-			case 1:
-				{
-				State = 1306;
-				Match(OR);
-				State = 1307;
-				compound_stmt();
-				}
-				break;
-			}
-			State = 1312;
+			compound_stmt();
+			State = 1311;
 			ErrorHandler.Sync(this);
 			switch ( Interpreter.AdaptivePredict(TokenStream,162,Context) ) {
 			case 1:
 				{
+				State = 1309;
+				Match(OR);
 				State = 1310;
+				compound_stmt();
+				}
+				break;
+			}
+			State = 1315;
+			ErrorHandler.Sync(this);
+			switch ( Interpreter.AdaptivePredict(TokenStream,163,Context) ) {
+			case 1:
+				{
+				State = 1313;
 				Match(THEN);
-				State = 1311;
+				State = 1314;
 				compound_stmt();
 				}
 				break;
@@ -8002,32 +8016,32 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1314;
+			State = 1317;
 			Match(WHILE);
-			State = 1315;
+			State = 1318;
 			expression();
-			State = 1316;
-			compound_stmt();
 			State = 1319;
-			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,163,Context) ) {
-			case 1:
-				{
-				State = 1317;
-				Match(OR);
-				State = 1318;
-				compound_stmt();
-				}
-				break;
-			}
-			State = 1323;
+			compound_stmt();
+			State = 1322;
 			ErrorHandler.Sync(this);
 			switch ( Interpreter.AdaptivePredict(TokenStream,164,Context) ) {
 			case 1:
 				{
+				State = 1320;
+				Match(OR);
 				State = 1321;
+				compound_stmt();
+				}
+				break;
+			}
+			State = 1326;
+			ErrorHandler.Sync(this);
+			switch ( Interpreter.AdaptivePredict(TokenStream,165,Context) ) {
+			case 1:
+				{
+				State = 1324;
 				Match(THEN);
-				State = 1322;
+				State = 1325;
 				compound_stmt();
 				}
 				break;
@@ -8085,40 +8099,40 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1325;
+			State = 1328;
 			Match(IF);
-			State = 1326;
+			State = 1329;
 			expression();
-			State = 1327;
+			State = 1330;
 			compound_stmt();
-			State = 1334;
+			State = 1337;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,165,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,166,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1328;
+					State = 1331;
 					Match(ELIF);
-					State = 1329;
+					State = 1332;
 					expression();
-					State = 1330;
+					State = 1333;
 					compound_stmt();
 					}
 					} 
 				}
-				State = 1336;
+				State = 1339;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,165,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,166,Context);
 			}
-			State = 1339;
+			State = 1342;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,166,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,167,Context) ) {
 			case 1:
 				{
-				State = 1337;
+				State = 1340;
 				Match(ELSE);
-				State = 1338;
+				State = 1341;
 				compound_stmt();
 				}
 				break;
@@ -8167,19 +8181,19 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1341;
+			State = 1344;
 			unpack();
-			State = 1343;
+			State = 1346;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (((((_la - 39)) & ~0x3f) == 0 && ((1L << (_la - 39)) & 671088641L) != 0)) {
 				{
-				State = 1342;
+				State = 1345;
 				stmt_modifier();
 				}
 			}
 
-			State = 1345;
+			State = 1348;
 			eos();
 			}
 		}
@@ -8227,23 +8241,23 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1347;
-			declaration();
-			State = 1348;
-			Match(COMMA);
 			State = 1350;
+			declaration();
+			State = 1351;
+			Match(COMMA);
+			State = 1353;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==ID) {
 				{
-				State = 1349;
+				State = 1352;
 				declaration_list();
 				}
 			}
 
-			State = 1352;
+			State = 1355;
 			Match(ASSIGN);
-			State = 1353;
+			State = 1356;
 			array_or_expression();
 			}
 		}
@@ -8290,21 +8304,21 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1355;
+			State = 1358;
 			declaration();
-			State = 1360;
+			State = 1363;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (_la==COMMA) {
 				{
 				{
-				State = 1356;
+				State = 1359;
 				Match(COMMA);
-				State = 1357;
+				State = 1360;
 				declaration();
 				}
 				}
-				State = 1362;
+				State = 1365;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
@@ -8348,16 +8362,16 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1363;
-			Match(ID);
 			State = 1366;
+			Match(ID);
+			State = 1369;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==AS) {
 				{
-				State = 1364;
+				State = 1367;
 				Match(AS);
-				State = 1365;
+				State = 1368;
 				type_reference();
 				}
 			}
@@ -8405,14 +8419,14 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 206, RULE_array_or_expression);
 		try {
 			int _alt;
-			State = 1380;
+			State = 1383;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,173,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,174,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
 				{
-				State = 1368;
+				State = 1371;
 				Match(COMMA);
 				}
 				}
@@ -8420,32 +8434,32 @@ public partial class BooParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1369;
+				State = 1372;
 				expression();
-				State = 1374;
+				State = 1377;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,171,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,172,Context);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1370;
+						State = 1373;
 						Match(COMMA);
-						State = 1371;
+						State = 1374;
 						expression();
 						}
 						} 
 					}
-					State = 1376;
+					State = 1379;
 					ErrorHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(TokenStream,171,Context);
+					_alt = Interpreter.AdaptivePredict(TokenStream,172,Context);
 				}
-				State = 1378;
+				State = 1381;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,172,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,173,Context) ) {
 				case 1:
 					{
-					State = 1377;
+					State = 1380;
 					Match(COMMA);
 					}
 					break;
@@ -8500,25 +8514,25 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1382;
+			State = 1385;
 			boolean_expression();
-			State = 1387;
+			State = 1390;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,174,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,175,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1383;
+					State = 1386;
 					Match(FOR);
-					State = 1384;
+					State = 1387;
 					generator_expression_body();
 					}
 					} 
 				}
-				State = 1389;
+				State = 1392;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,174,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,175,Context);
 			}
 			}
 		}
@@ -8564,18 +8578,18 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1390;
+			State = 1393;
 			declaration_list();
-			State = 1391;
-			Match(IN);
-			State = 1392;
-			boolean_expression();
 			State = 1394;
+			Match(IN);
+			State = 1395;
+			boolean_expression();
+			State = 1397;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,175,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,176,Context) ) {
 			case 1:
 				{
-				State = 1393;
+				State = 1396;
 				stmt_modifier();
 				}
 				break;
@@ -8625,25 +8639,25 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1396;
+			State = 1399;
 			boolean_term();
-			State = 1401;
+			State = 1404;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,176,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,177,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1397;
+					State = 1400;
 					Match(OR);
-					State = 1398;
+					State = 1401;
 					boolean_term();
 					}
 					} 
 				}
-				State = 1403;
+				State = 1406;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,176,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,177,Context);
 			}
 			}
 		}
@@ -8690,25 +8704,25 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1404;
+			State = 1407;
 			not_expression();
-			State = 1409;
+			State = 1412;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,177,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,178,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1405;
+					State = 1408;
 					Match(AND);
-					State = 1406;
+					State = 1409;
 					not_expression();
 					}
 					} 
 				}
-				State = 1411;
+				State = 1414;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,177,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,178,Context);
 			}
 			}
 		}
@@ -8747,7 +8761,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1412;
+			State = 1415;
 			callable_expression();
 			}
 		}
@@ -8797,25 +8811,25 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1414;
+			State = 1417;
 			Match(QQ_BEGIN);
-			State = 1422;
+			State = 1425;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,179,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,180,Context) ) {
 			case 1:
 				{
-				State = 1415;
+				State = 1418;
 				Match(INDENT);
-				State = 1416;
-				ast_literal_block();
-				State = 1417;
-				Match(DEDENT);
 				State = 1419;
+				ast_literal_block();
+				State = 1420;
+				Match(DEDENT);
+				State = 1422;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==EOL || _la==EOS) {
 					{
-					State = 1418;
+					State = 1421;
 					eos();
 					}
 				}
@@ -8824,12 +8838,12 @@ public partial class BooParser : Parser {
 				break;
 			case 2:
 				{
-				State = 1421;
+				State = 1424;
 				ast_literal_closure();
 				}
 				break;
 			}
-			State = 1424;
+			State = 1427;
 			Match(QQ_END);
 			}
 		}
@@ -8868,7 +8882,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1426;
+			State = 1429;
 			parse_module();
 			}
 		}
@@ -8919,13 +8933,13 @@ public partial class BooParser : Parser {
 		int _la;
 		try {
 			int _alt;
-			State = 1439;
+			State = 1442;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,182,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,183,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1429;
+				State = 1432;
 				ErrorHandler.Sync(this);
 				_alt = 1;
 				do {
@@ -8933,7 +8947,7 @@ public partial class BooParser : Parser {
 					case 1:
 						{
 						{
-						State = 1428;
+						State = 1431;
 						stmt();
 						}
 						}
@@ -8941,35 +8955,35 @@ public partial class BooParser : Parser {
 					default:
 						throw new NoViableAltException(this);
 					}
-					State = 1431;
+					State = 1434;
 					ErrorHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(TokenStream,180,Context);
+					_alt = Interpreter.AdaptivePredict(TokenStream,181,Context);
 				} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER );
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1434;
+				State = 1437;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				do {
 					{
 					{
-					State = 1433;
+					State = 1436;
 					type_definition_member();
 					}
 					}
-					State = 1436;
+					State = 1439;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
-				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & -5035442094420619136L) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & 68157449L) != 0) );
+				} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & -5017427695911137152L) != 0) || ((((_la - 67)) & ~0x3f) == 0 && ((1L << (_la - 67)) & 68157449L) != 0) );
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1438;
+				State = 1441;
 				ast_literal_module();
 				}
 				break;
@@ -9028,22 +9042,22 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 224, RULE_ast_literal_closure);
 		int _la;
 		try {
-			State = 1457;
+			State = 1460;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,186,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,187,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1441;
-				expression();
 				State = 1444;
+				expression();
+				State = 1447;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COLON) {
 					{
-					State = 1442;
+					State = 1445;
 					Match(COLON);
-					State = 1443;
+					State = 1446;
 					expression();
 					}
 				}
@@ -9053,36 +9067,36 @@ public partial class BooParser : Parser {
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1446;
+				State = 1449;
 				import_directive_();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1447;
+				State = 1450;
 				internal_closure_stmt();
-				State = 1454;
+				State = 1457;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==EOL || _la==EOS) {
 					{
 					{
-					State = 1448;
+					State = 1451;
 					eos();
-					State = 1450;
+					State = 1453;
 					ErrorHandler.Sync(this);
-					switch ( Interpreter.AdaptivePredict(TokenStream,184,Context) ) {
+					switch ( Interpreter.AdaptivePredict(TokenStream,185,Context) ) {
 					case 1:
 						{
-						State = 1449;
+						State = 1452;
 						internal_closure_stmt();
 						}
 						break;
 					}
 					}
 					}
-					State = 1456;
+					State = 1459;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
@@ -9141,38 +9155,38 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1459;
+			State = 1462;
 			slicing_expression();
-			State = 1473;
+			State = 1476;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case DEF:
 			case DO:
 			case COLON:
 				{
-				State = 1460;
+				State = 1463;
 				method_invocation_block();
 				}
 				break;
 			case ASSIGN:
 				{
-				State = 1461;
+				State = 1464;
 				Match(ASSIGN);
-				State = 1471;
+				State = 1474;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,188,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,189,Context) ) {
 				case 1:
 					{
-					State = 1462;
+					State = 1465;
 					array_or_expression();
-					State = 1468;
+					State = 1471;
 					ErrorHandler.Sync(this);
 					switch (TokenStream.LA(1)) {
 					case DEF:
 					case DO:
 					case COLON:
 						{
-						State = 1463;
+						State = 1466;
 						method_invocation_block();
 						}
 						break;
@@ -9180,16 +9194,16 @@ public partial class BooParser : Parser {
 					case UNLESS:
 					case WHILE:
 						{
-						State = 1464;
+						State = 1467;
 						stmt_modifier();
-						State = 1465;
+						State = 1468;
 						eos();
 						}
 						break;
 					case EOL:
 					case EOS:
 						{
-						State = 1467;
+						State = 1470;
 						eos();
 						}
 						break;
@@ -9200,7 +9214,7 @@ public partial class BooParser : Parser {
 					break;
 				case 2:
 					{
-					State = 1470;
+					State = 1473;
 					callable_expression();
 					}
 					break;
@@ -9251,11 +9265,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1475;
+			State = 1478;
 			slicing_expression();
-			State = 1476;
+			State = 1479;
 			Match(ASSIGN);
-			State = 1477;
+			State = 1480;
 			array_or_expression();
 			}
 		}
@@ -9296,22 +9310,22 @@ public partial class BooParser : Parser {
 		Not_expressionContext _localctx = new Not_expressionContext(Context, State);
 		EnterRule(_localctx, 230, RULE_not_expression);
 		try {
-			State = 1482;
+			State = 1485;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,190,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,191,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1479;
+				State = 1482;
 				Match(NOT);
-				State = 1480;
+				State = 1483;
 				not_expression();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1481;
+				State = 1484;
 				assignment_expression();
 				}
 				break;
@@ -9362,14 +9376,14 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1484;
-			conditional_expression();
 			State = 1487;
+			conditional_expression();
+			State = 1490;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,191,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,192,Context) ) {
 			case 1:
 				{
-				State = 1485;
+				State = 1488;
 				_la = TokenStream.LA(1);
 				if ( !(((((_la - 80)) & ~0x3f) == 0 && ((1L << (_la - 80)) & 1212153877L) != 0)) ) {
 				ErrorHandler.RecoverInline(this);
@@ -9378,7 +9392,7 @@ public partial class BooParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 1486;
+				State = 1489;
 				assignment_expression();
 				}
 				break;
@@ -9430,7 +9444,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1503;
+			State = 1506;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case IS:
@@ -9440,65 +9454,65 @@ public partial class BooParser : Parser {
 			case GREATER_THAN:
 			case CMP_OPERATOR:
 				{
-				State = 1498;
+				State = 1501;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,192,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,193,Context) ) {
 				case 1:
 					{
-					State = 1489;
+					State = 1492;
 					Match(CMP_OPERATOR);
 					}
 					break;
 				case 2:
 					{
-					State = 1490;
+					State = 1493;
 					Match(GREATER_THAN);
 					}
 					break;
 				case 3:
 					{
-					State = 1491;
+					State = 1494;
 					Match(LESS_THAN);
 					}
 					break;
 				case 4:
 					{
-					State = 1492;
+					State = 1495;
 					Match(IS);
-					State = 1493;
+					State = 1496;
 					Match(NOT);
 					}
 					break;
 				case 5:
 					{
-					State = 1494;
+					State = 1497;
 					Match(IS);
 					}
 					break;
 				case 6:
 					{
-					State = 1495;
+					State = 1498;
 					Match(NOT);
-					State = 1496;
+					State = 1499;
 					Match(IN);
 					}
 					break;
 				case 7:
 					{
-					State = 1497;
+					State = 1500;
 					Match(IN);
 					}
 					break;
 				}
-				State = 1500;
+				State = 1503;
 				sum();
 				}
 				break;
 			case ISA:
 				{
-				State = 1501;
+				State = 1504;
 				Match(ISA);
-				State = 1502;
+				State = 1505;
 				type_reference();
 				}
 				break;
@@ -9549,23 +9563,23 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1505;
+			State = 1508;
 			sum();
-			State = 1509;
+			State = 1512;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,194,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,195,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1506;
+					State = 1509;
 					any_cond_expr_value();
 					}
 					} 
 				}
-				State = 1511;
+				State = 1514;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,194,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,195,Context);
 			}
 			}
 		}
@@ -9610,7 +9624,7 @@ public partial class BooParser : Parser {
 			EnterOuterAlt(_localctx, 1);
 			{
 			{
-			State = 1512;
+			State = 1515;
 			_la = TokenStream.LA(1);
 			if ( !(((((_la - 79)) & ~0x3f) == 0 && ((1L << (_la - 79)) & 1572881L) != 0)) ) {
 			ErrorHandler.RecoverInline(this);
@@ -9619,7 +9633,7 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 1513;
+			State = 1516;
 			term();
 			}
 			}
@@ -9666,23 +9680,23 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1515;
+			State = 1518;
 			term();
-			State = 1519;
+			State = 1522;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,195,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,196,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1516;
+					State = 1519;
 					any_sum_value();
 					}
 					} 
 				}
-				State = 1521;
+				State = 1524;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,195,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,196,Context);
 			}
 			}
 		}
@@ -9727,7 +9741,7 @@ public partial class BooParser : Parser {
 			EnterOuterAlt(_localctx, 1);
 			{
 			{
-			State = 1522;
+			State = 1525;
 			_la = TokenStream.LA(1);
 			if ( !(((((_la - 81)) & ~0x3f) == 0 && ((1L << (_la - 81)) & 9961473L) != 0)) ) {
 			ErrorHandler.RecoverInline(this);
@@ -9736,7 +9750,7 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 1523;
+			State = 1526;
 			factor();
 			}
 			}
@@ -9783,23 +9797,23 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1525;
+			State = 1528;
 			factor();
-			State = 1529;
+			State = 1532;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,196,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,197,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1526;
+					State = 1529;
 					any_term_value();
 					}
 					} 
 				}
-				State = 1531;
+				State = 1534;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,196,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,197,Context);
 			}
 			}
 		}
@@ -9842,7 +9856,7 @@ public partial class BooParser : Parser {
 			EnterOuterAlt(_localctx, 1);
 			{
 			{
-			State = 1532;
+			State = 1535;
 			_la = TokenStream.LA(1);
 			if ( !(_la==SHIFT_LEFT || _la==SHIFT_RIGHT) ) {
 			ErrorHandler.RecoverInline(this);
@@ -9851,7 +9865,7 @@ public partial class BooParser : Parser {
 				ErrorHandler.ReportMatch(this);
 			    Consume();
 			}
-			State = 1533;
+			State = 1536;
 			exponentiation();
 			}
 			}
@@ -9898,23 +9912,23 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1535;
+			State = 1538;
 			exponentiation();
-			State = 1539;
+			State = 1542;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,197,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,198,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1536;
+					State = 1539;
 					any_factor_value();
 					}
 					} 
 				}
-				State = 1541;
+				State = 1544;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,197,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,198,Context);
 			}
 			}
 		}
@@ -9969,45 +9983,45 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1542;
+			State = 1545;
 			unary_expression();
-			State = 1547;
+			State = 1550;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,198,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,199,Context) ) {
 			case 1:
 				{
-				State = 1543;
+				State = 1546;
 				Match(AS);
-				State = 1544;
+				State = 1547;
 				type_reference();
 				}
 				break;
 			case 2:
 				{
-				State = 1545;
+				State = 1548;
 				Match(CAST);
-				State = 1546;
+				State = 1549;
 				type_reference();
 				}
 				break;
 			}
-			State = 1553;
+			State = 1556;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,199,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,200,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1549;
+					State = 1552;
 					Match(EXPONENTIATION);
-					State = 1550;
+					State = 1553;
 					exponentiation();
 					}
 					} 
 				}
-				State = 1555;
+				State = 1558;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,199,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,200,Context);
 			}
 			}
 		}
@@ -10056,22 +10070,22 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 252, RULE_unary_expression);
 		int _la;
 		try {
-			State = 1564;
+			State = 1567;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,201,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,202,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1556;
+				State = 1559;
 				if (!(InputStream.LA(1) == SUBTRACT && InputStream.LA(2) == LONG)) throw new FailedPredicateException(this, "InputStream.LA(1) == SUBTRACT && InputStream.LA(2) == LONG");
-				State = 1557;
+				State = 1560;
 				integer_literal();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1558;
+				State = 1561;
 				_la = TokenStream.LA(1);
 				if ( !(((((_la - 96)) & ~0x3f) == 0 && ((1L << (_la - 96)) & 32811L) != 0)) ) {
 				ErrorHandler.RecoverInline(this);
@@ -10080,21 +10094,21 @@ public partial class BooParser : Parser {
 					ErrorHandler.ReportMatch(this);
 				    Consume();
 				}
-				State = 1559;
+				State = 1562;
 				unary_expression();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1560;
+				State = 1563;
 				slicing_expression();
-				State = 1562;
+				State = 1565;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,200,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,201,Context) ) {
 				case 1:
 					{
-					State = 1561;
+					State = 1564;
 					_la = TokenStream.LA(1);
 					if ( !(_la==INCREMENT || _la==DECREMENT) ) {
 					ErrorHandler.RecoverInline(this);
@@ -10164,62 +10178,62 @@ public partial class BooParser : Parser {
 		AtomContext _localctx = new AtomContext(Context, State);
 		EnterRule(_localctx, 254, RULE_atom);
 		try {
-			State = 1574;
+			State = 1577;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,202,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,203,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1566;
+				State = 1569;
 				literal();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1567;
+				State = 1570;
 				char_literal();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1568;
+				State = 1571;
 				reference_expression();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 1569;
+				State = 1572;
 				paren_expression();
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 1570;
+				State = 1573;
 				cast_expression();
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 1571;
+				State = 1574;
 				typeof_expression();
 				}
 				break;
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 1572;
+				State = 1575;
 				splice_expression();
 				}
 				break;
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 1573;
+				State = 1576;
 				omitted_member_expression();
 				}
 				break;
@@ -10261,9 +10275,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1576;
+			State = 1579;
 			Match(DOT);
-			State = 1577;
+			State = 1580;
 			member();
 			}
 		}
@@ -10303,9 +10317,9 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1579;
+			State = 1582;
 			Match(SPLICE_BEGIN);
-			State = 1580;
+			State = 1583;
 			atom();
 			}
 		}
@@ -10347,16 +10361,16 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1582;
-			Match(CHAR);
-			State = 1583;
-			Match(LPAREN);
 			State = 1585;
+			Match(CHAR);
+			State = 1586;
+			Match(LPAREN);
+			State = 1588;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==INT || _la==SINGLE_QUOTED_STRING) {
 				{
-				State = 1584;
+				State = 1587;
 				_la = TokenStream.LA(1);
 				if ( !(_la==INT || _la==SINGLE_QUOTED_STRING) ) {
 				ErrorHandler.RecoverInline(this);
@@ -10368,7 +10382,7 @@ public partial class BooParser : Parser {
 				}
 			}
 
-			State = 1587;
+			State = 1590;
 			Match(RPAREN);
 			}
 		}
@@ -10414,17 +10428,17 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1589;
-			Match(CAST);
-			State = 1590;
-			Match(LPAREN);
-			State = 1591;
-			type_reference();
 			State = 1592;
-			Match(COMMA);
+			Match(CAST);
 			State = 1593;
-			expression();
+			Match(LPAREN);
 			State = 1594;
+			type_reference();
+			State = 1595;
+			Match(COMMA);
+			State = 1596;
+			expression();
+			State = 1597;
 			Match(RPAREN);
 			}
 		}
@@ -10466,13 +10480,13 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1596;
-			Match(TYPEOF);
-			State = 1597;
-			Match(LPAREN);
-			State = 1598;
-			type_reference();
 			State = 1599;
+			Match(TYPEOF);
+			State = 1600;
+			Match(LPAREN);
+			State = 1601;
+			type_reference();
+			State = 1602;
 			Match(RPAREN);
 			}
 		}
@@ -10510,21 +10524,21 @@ public partial class BooParser : Parser {
 		Reference_expressionContext _localctx = new Reference_expressionContext(Context, State);
 		EnterRule(_localctx, 266, RULE_reference_expression);
 		try {
-			State = 1603;
+			State = 1606;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case THEN:
 			case ID:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1601;
+				State = 1604;
 				macro_name();
 				}
 				break;
 			case CHAR:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1602;
+				State = 1605;
 				Match(CHAR);
 				}
 				break;
@@ -10579,40 +10593,40 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 268, RULE_paren_expression);
 		int _la;
 		try {
-			State = 1617;
+			State = 1620;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,206,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,207,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1605;
+				State = 1608;
 				typed_array();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1606;
+				State = 1609;
 				Match(LPAREN);
-				State = 1607;
+				State = 1610;
 				array_or_expression();
-				State = 1613;
+				State = 1616;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==IF) {
 					{
-					State = 1608;
-					Match(IF);
-					State = 1609;
-					boolean_expression();
-					State = 1610;
-					Match(ELSE);
 					State = 1611;
+					Match(IF);
+					State = 1612;
+					boolean_expression();
+					State = 1613;
+					Match(ELSE);
+					State = 1614;
 					array_or_expression();
 					}
 				}
 
-				State = 1615;
+				State = 1618;
 				Match(RPAREN);
 				}
 				break;
@@ -10669,51 +10683,51 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1619;
-			Match(LPAREN);
-			State = 1620;
-			Match(OF);
-			State = 1621;
-			type_reference();
 			State = 1622;
+			Match(LPAREN);
+			State = 1623;
+			Match(OF);
+			State = 1624;
+			type_reference();
+			State = 1625;
 			Match(COLON);
-			State = 1635;
+			State = 1638;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,209,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,210,Context) ) {
 			case 1:
 				{
-				State = 1623;
+				State = 1626;
 				Match(COMMA);
 				}
 				break;
 			case 2:
 				{
-				State = 1624;
+				State = 1627;
 				expression();
-				State = 1629;
+				State = 1632;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,207,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,208,Context);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1625;
+						State = 1628;
 						Match(COMMA);
-						State = 1626;
+						State = 1629;
 						expression();
 						}
 						} 
 					}
-					State = 1631;
+					State = 1634;
 					ErrorHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(TokenStream,207,Context);
+					_alt = Interpreter.AdaptivePredict(TokenStream,208,Context);
 				}
-				State = 1633;
+				State = 1636;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COMMA) {
 					{
-					State = 1632;
+					State = 1635;
 					Match(COMMA);
 					}
 				}
@@ -10721,7 +10735,7 @@ public partial class BooParser : Parser {
 				}
 				break;
 			}
-			State = 1637;
+			State = 1640;
 			Match(RPAREN);
 			}
 		}
@@ -10767,7 +10781,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1639;
+			State = 1642;
 			_la = TokenStream.LA(1);
 			if ( !(((((_la - 25)) & ~0x3f) == 0 && ((1L << (_la - 25)) & 52779343153281L) != 0)) ) {
 			ErrorHandler.RecoverInline(this);
@@ -10817,22 +10831,22 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1641;
+			State = 1644;
 			Match(COLON);
-			State = 1646;
+			State = 1649;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,210,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,211,Context) ) {
 			case 1:
 				{
-				State = 1642;
+				State = 1645;
 				expression();
 				}
 				break;
 			case 2:
 				{
-				State = 1643;
+				State = 1646;
 				Match(COLON);
-				State = 1644;
+				State = 1647;
 				expression();
 				}
 				break;
@@ -10886,33 +10900,33 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1648;
+			State = 1651;
 			expression();
-			State = 1657;
+			State = 1660;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==COLON) {
 				{
-				State = 1649;
+				State = 1652;
 				Match(COLON);
-				State = 1651;
+				State = 1654;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,211,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,212,Context) ) {
 				case 1:
 					{
-					State = 1650;
+					State = 1653;
 					expression();
 					}
 					break;
 				}
-				State = 1655;
+				State = 1658;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COLON) {
 					{
-					State = 1653;
+					State = 1656;
 					Match(COLON);
-					State = 1654;
+					State = 1657;
 					expression();
 					}
 				}
@@ -10958,20 +10972,20 @@ public partial class BooParser : Parser {
 		SliceContext _localctx = new SliceContext(Context, State);
 		EnterRule(_localctx, 278, RULE_slice);
 		try {
-			State = 1661;
+			State = 1664;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,214,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,215,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1659;
+				State = 1662;
 				slice_no_begin();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1660;
+				State = 1663;
 				slice_with_begin();
 				}
 				break;
@@ -11013,14 +11027,14 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1663;
+			State = 1666;
 			atom();
-			State = 1665;
+			State = 1668;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,215,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,216,Context) ) {
 			case 1:
 				{
-				State = 1664;
+				State = 1667;
 				Match(NULLABLE_SUFFIX);
 				}
 				break;
@@ -11102,55 +11116,55 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1714;
+			State = 1717;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case LBRACK:
 				{
-				State = 1667;
+				State = 1670;
 				Match(LBRACK);
-				State = 1678;
+				State = 1681;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,217,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,218,Context) ) {
 				case 1:
 					{
-					State = 1668;
+					State = 1671;
 					Match(OF);
-					State = 1669;
+					State = 1672;
 					type_reference_list();
 					}
 					break;
 				case 2:
 					{
-					State = 1670;
+					State = 1673;
 					slice();
-					State = 1675;
+					State = 1678;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					while (_la==COMMA) {
 						{
 						{
-						State = 1671;
+						State = 1674;
 						Match(COMMA);
-						State = 1672;
+						State = 1675;
 						slice();
 						}
 						}
-						State = 1677;
+						State = 1680;
 						ErrorHandler.Sync(this);
 						_la = TokenStream.LA(1);
 					}
 					}
 					break;
 				}
-				State = 1680;
+				State = 1683;
 				Match(RBRACK);
-				State = 1682;
+				State = 1685;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,218,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,219,Context) ) {
 				case 1:
 					{
-					State = 1681;
+					State = 1684;
 					Match(NULLABLE_SUFFIX);
 					}
 					break;
@@ -11159,17 +11173,17 @@ public partial class BooParser : Parser {
 				break;
 			case OF:
 				{
-				State = 1684;
+				State = 1687;
 				Match(OF);
-				State = 1685;
+				State = 1688;
 				type_reference();
 				}
 				break;
 			case DOT:
 				{
-				State = 1686;
+				State = 1689;
 				Match(DOT);
-				State = 1690;
+				State = 1693;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case EVENT:
@@ -11182,27 +11196,27 @@ public partial class BooParser : Parser {
 				case YIELD:
 				case ID:
 					{
-					State = 1687;
+					State = 1690;
 					member();
 					}
 					break;
 				case SPLICE_BEGIN:
 					{
-					State = 1688;
+					State = 1691;
 					Match(SPLICE_BEGIN);
-					State = 1689;
+					State = 1692;
 					atom();
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1693;
+				State = 1696;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,220,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,221,Context) ) {
 				case 1:
 					{
-					State = 1692;
+					State = 1695;
 					Match(NULLABLE_SUFFIX);
 					}
 					break;
@@ -11211,58 +11225,58 @@ public partial class BooParser : Parser {
 				break;
 			case LPAREN:
 				{
-				State = 1695;
+				State = 1698;
 				Match(LPAREN);
-				State = 1704;
+				State = 1707;
 				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,222,Context) ) {
+				switch ( Interpreter.AdaptivePredict(TokenStream,223,Context) ) {
 				case 1:
 					{
-					State = 1696;
+					State = 1699;
 					argument();
-					State = 1701;
+					State = 1704;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					while (_la==COMMA) {
 						{
 						{
-						State = 1697;
+						State = 1700;
 						Match(COMMA);
-						State = 1698;
+						State = 1701;
 						argument();
 						}
 						}
-						State = 1703;
+						State = 1706;
 						ErrorHandler.Sync(this);
 						_la = TokenStream.LA(1);
 					}
 					}
 					break;
 				}
-				State = 1706;
+				State = 1709;
 				Match(RPAREN);
-				State = 1708;
-				ErrorHandler.Sync(this);
-				switch ( Interpreter.AdaptivePredict(TokenStream,223,Context) ) {
-				case 1:
-					{
-					State = 1707;
-					Match(NULLABLE_SUFFIX);
-					}
-					break;
-				}
-				State = 1712;
+				State = 1711;
 				ErrorHandler.Sync(this);
 				switch ( Interpreter.AdaptivePredict(TokenStream,224,Context) ) {
 				case 1:
 					{
 					State = 1710;
+					Match(NULLABLE_SUFFIX);
+					}
+					break;
+				}
+				State = 1715;
+				ErrorHandler.Sync(this);
+				switch ( Interpreter.AdaptivePredict(TokenStream,225,Context) ) {
+				case 1:
+					{
+					State = 1713;
 					hash_literal();
 					}
 					break;
 				case 2:
 					{
-					State = 1711;
+					State = 1714;
 					list_initializer();
 					}
 					break;
@@ -11316,23 +11330,23 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1716;
+			State = 1719;
 			safe_atom();
-			State = 1720;
+			State = 1723;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,226,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,227,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1717;
+					State = 1720;
 					any_slice_expr_value();
 					}
 					} 
 				}
-				State = 1722;
+				State = 1725;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,226,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,227,Context);
 			}
 			}
 		}
@@ -11373,11 +11387,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1723;
+			State = 1726;
 			Match(LBRACE);
-			State = 1724;
+			State = 1727;
 			list_items();
-			State = 1725;
+			State = 1728;
 			Match(RBRACE);
 			}
 		}
@@ -11450,97 +11464,97 @@ public partial class BooParser : Parser {
 		LiteralContext _localctx = new LiteralContext(Context, State);
 		EnterRule(_localctx, 288, RULE_literal);
 		try {
-			State = 1740;
+			State = 1743;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,227,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,228,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1727;
+				State = 1730;
 				integer_literal();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1728;
+				State = 1731;
 				string_literal();
 				}
 				break;
 			case 3:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1729;
+				State = 1732;
 				list_literal();
 				}
 				break;
 			case 4:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 1730;
+				State = 1733;
 				hash_literal();
 				}
 				break;
 			case 5:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 1731;
+				State = 1734;
 				closure_expression();
 				}
 				break;
 			case 6:
 				EnterOuterAlt(_localctx, 6);
 				{
-				State = 1732;
+				State = 1735;
 				ast_literal_expression();
 				}
 				break;
 			case 7:
 				EnterOuterAlt(_localctx, 7);
 				{
-				State = 1733;
+				State = 1736;
 				re_literal();
 				}
 				break;
 			case 8:
 				EnterOuterAlt(_localctx, 8);
 				{
-				State = 1734;
+				State = 1737;
 				bool_literal();
 				}
 				break;
 			case 9:
 				EnterOuterAlt(_localctx, 9);
 				{
-				State = 1735;
+				State = 1738;
 				null_literal();
 				}
 				break;
 			case 10:
 				EnterOuterAlt(_localctx, 10);
 				{
-				State = 1736;
+				State = 1739;
 				self_literal();
 				}
 				break;
 			case 11:
 				EnterOuterAlt(_localctx, 11);
 				{
-				State = 1737;
+				State = 1740;
 				super_literal();
 				}
 				break;
 			case 12:
 				EnterOuterAlt(_localctx, 12);
 				{
-				State = 1738;
+				State = 1741;
 				double_literal();
 				}
 				break;
 			case 13:
 				EnterOuterAlt(_localctx, 13);
 				{
-				State = 1739;
+				State = 1742;
 				timespan_literal();
 				}
 				break;
@@ -11579,7 +11593,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1742;
+			State = 1745;
 			Match(SELF);
 			}
 		}
@@ -11616,7 +11630,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1744;
+			State = 1747;
 			Match(SUPER);
 			}
 		}
@@ -11653,7 +11667,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1746;
+			State = 1749;
 			Match(NULL);
 			}
 		}
@@ -11692,7 +11706,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1748;
+			State = 1751;
 			_la = TokenStream.LA(1);
 			if ( !(_la==FALSE || _la==TRUE) ) {
 			ErrorHandler.RecoverInline(this);
@@ -11739,17 +11753,17 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1751;
+			State = 1754;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==SUBTRACT) {
 				{
-				State = 1750;
+				State = 1753;
 				Match(SUBTRACT);
 				}
 			}
 
-			State = 1753;
+			State = 1756;
 			_la = TokenStream.LA(1);
 			if ( !(_la==INT || _la==LONG) ) {
 			ErrorHandler.RecoverInline(this);
@@ -11801,41 +11815,41 @@ public partial class BooParser : Parser {
 		String_literalContext _localctx = new String_literalContext(Context, State);
 		EnterRule(_localctx, 300, RULE_string_literal);
 		try {
-			State = 1760;
+			State = 1763;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case ESEPARATOR:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1755;
+				State = 1758;
 				expression_interpolation();
 				}
 				break;
 			case DOUBLE_QUOTED_STRING:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1756;
+				State = 1759;
 				double_quoted_string();
 				}
 				break;
 			case SINGLE_QUOTED_STRING:
 				EnterOuterAlt(_localctx, 3);
 				{
-				State = 1757;
+				State = 1760;
 				Match(SINGLE_QUOTED_STRING);
 				}
 				break;
 			case TRIPLE_QUOTED_STRING:
 				EnterOuterAlt(_localctx, 4);
 				{
-				State = 1758;
+				State = 1761;
 				triple_quoted_string();
 				}
 				break;
 			case BACKTICK_QUOTED_STRING:
 				EnterOuterAlt(_localctx, 5);
 				{
-				State = 1759;
+				State = 1762;
 				Match(BACKTICK_QUOTED_STRING);
 				}
 				break;
@@ -11920,75 +11934,75 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1762;
+			State = 1765;
 			Match(DOUBLE_QUOTED_STRING);
-			State = 1784;
+			State = 1787;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (((((_la - 126)) & ~0x3f) == 0 && ((1L << (_la - 126)) & 31L) != 0)) {
 				{
-				State = 1782;
+				State = 1785;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case TEXT:
 					{
-					State = 1763;
+					State = 1766;
 					Match(TEXT);
 					}
 					break;
 				case DQS_ESC:
 					{
-					State = 1764;
+					State = 1767;
 					Match(DQS_ESC);
 					}
 					break;
 				case INTERPOLATED_EXPRESSION_LBRACE:
 					{
-					State = 1765;
+					State = 1768;
 					Match(INTERPOLATED_EXPRESSION_LBRACE);
-					State = 1766;
-					expression();
 					State = 1769;
+					expression();
+					State = 1772;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==COLON) {
 						{
-						State = 1767;
+						State = 1770;
 						Match(COLON);
-						State = 1768;
+						State = 1771;
 						Match(ID);
 						}
 					}
 
-					State = 1771;
+					State = 1774;
 					Match(RBRACE);
 					}
 					break;
 				case INTERPOLATED_EXPRESSION_LPAREN:
 					{
-					State = 1773;
+					State = 1776;
 					Match(INTERPOLATED_EXPRESSION_LPAREN);
-					State = 1774;
-					expression();
 					State = 1777;
+					expression();
+					State = 1780;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==COLON) {
 						{
-						State = 1775;
+						State = 1778;
 						Match(COLON);
-						State = 1776;
+						State = 1779;
 						Match(ID);
 						}
 					}
 
-					State = 1779;
+					State = 1782;
 					Match(RPAREN);
 					}
 					break;
 				case INTERPOLATED_REFERENCE:
 					{
-					State = 1781;
+					State = 1784;
 					Match(INTERPOLATED_REFERENCE);
 					}
 					break;
@@ -11996,11 +12010,11 @@ public partial class BooParser : Parser {
 					throw new NoViableAltException(this);
 				}
 				}
-				State = 1786;
+				State = 1789;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
-			State = 1787;
+			State = 1790;
 			Match(DQS_END);
 			}
 		}
@@ -12077,69 +12091,69 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1789;
+			State = 1792;
 			Match(TRIPLE_QUOTED_STRING);
-			State = 1810;
+			State = 1813;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			while (((((_la - 127)) & ~0x3f) == 0 && ((1L << (_la - 127)) & 15L) != 0)) {
 				{
-				State = 1808;
+				State = 1811;
 				ErrorHandler.Sync(this);
 				switch (TokenStream.LA(1)) {
 				case TEXT:
 					{
-					State = 1790;
+					State = 1793;
 					Match(TEXT);
 					}
 					break;
 				case INTERPOLATED_EXPRESSION_LBRACE:
 					{
-					State = 1791;
+					State = 1794;
 					Match(INTERPOLATED_EXPRESSION_LBRACE);
-					State = 1792;
-					expression();
 					State = 1795;
+					expression();
+					State = 1798;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==COLON) {
 						{
-						State = 1793;
+						State = 1796;
 						Match(COLON);
-						State = 1794;
+						State = 1797;
 						Match(ID);
 						}
 					}
 
-					State = 1797;
+					State = 1800;
 					Match(RBRACE);
 					}
 					break;
 				case INTERPOLATED_EXPRESSION_LPAREN:
 					{
-					State = 1799;
+					State = 1802;
 					Match(INTERPOLATED_EXPRESSION_LPAREN);
-					State = 1800;
-					expression();
 					State = 1803;
+					expression();
+					State = 1806;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 					if (_la==COLON) {
 						{
-						State = 1801;
+						State = 1804;
 						Match(COLON);
-						State = 1802;
+						State = 1805;
 						Match(ID);
 						}
 					}
 
-					State = 1805;
+					State = 1808;
 					Match(RPAREN);
 					}
 					break;
 				case INTERPOLATED_REFERENCE:
 					{
-					State = 1807;
+					State = 1810;
 					Match(INTERPOLATED_REFERENCE);
 					}
 					break;
@@ -12147,11 +12161,11 @@ public partial class BooParser : Parser {
 					throw new NoViableAltException(this);
 				}
 				}
-				State = 1812;
+				State = 1815;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 			}
-			State = 1813;
+			State = 1816;
 			Match(TQS_END);
 			}
 		}
@@ -12198,31 +12212,31 @@ public partial class BooParser : Parser {
 			EnterOuterAlt(_localctx, 1);
 			{
 			{
-			State = 1815;
+			State = 1818;
 			Match(ESEPARATOR);
-			State = 1816;
+			State = 1819;
 			expression();
-			State = 1821;
+			State = 1824;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==ID || _la==COLON) {
 				{
-				State = 1818;
+				State = 1821;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COLON) {
 					{
-					State = 1817;
+					State = 1820;
 					Match(COLON);
 					}
 				}
 
-				State = 1820;
+				State = 1823;
 				Match(ID);
 				}
 			}
 
-			State = 1823;
+			State = 1826;
 			Match(ESEPARATOR);
 			}
 			}
@@ -12270,17 +12284,17 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1826;
+			State = 1829;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,240,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,241,Context) ) {
 			case 1:
 				{
-				State = 1825;
+				State = 1828;
 				Match(ESEPARATOR);
 				}
 				break;
 			}
-			State = 1829;
+			State = 1832;
 			ErrorHandler.Sync(this);
 			_alt = 1;
 			do {
@@ -12288,7 +12302,7 @@ public partial class BooParser : Parser {
 				case 1:
 					{
 					{
-					State = 1828;
+					State = 1831;
 					any_expr_interpolation_item();
 					}
 					}
@@ -12296,16 +12310,16 @@ public partial class BooParser : Parser {
 				default:
 					throw new NoViableAltException(this);
 				}
-				State = 1831;
+				State = 1834;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,241,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,242,Context);
 			} while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER );
-			State = 1834;
+			State = 1837;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,242,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,243,Context) ) {
 			case 1:
 				{
-				State = 1833;
+				State = 1836;
 				Match(ESEPARATOR);
 				}
 				break;
@@ -12349,11 +12363,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1836;
+			State = 1839;
 			Match(LBRACK);
-			State = 1837;
+			State = 1840;
 			list_items();
-			State = 1838;
+			State = 1841;
 			Match(RBRACK);
 			}
 		}
@@ -12401,37 +12415,37 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1851;
+			State = 1854;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,245,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,246,Context) ) {
 			case 1:
 				{
-				State = 1840;
+				State = 1843;
 				expression();
-				State = 1845;
+				State = 1848;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,243,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,244,Context);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1841;
+						State = 1844;
 						Match(COMMA);
-						State = 1842;
+						State = 1845;
 						expression();
 						}
 						} 
 					}
-					State = 1847;
+					State = 1850;
 					ErrorHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(TokenStream,243,Context);
+					_alt = Interpreter.AdaptivePredict(TokenStream,244,Context);
 				}
-				State = 1849;
+				State = 1852;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COMMA) {
 					{
-					State = 1848;
+					State = 1851;
 					Match(COMMA);
 					}
 				}
@@ -12487,39 +12501,39 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1853;
+			State = 1856;
 			Match(LBRACE);
-			State = 1865;
+			State = 1868;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,248,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,249,Context) ) {
 			case 1:
 				{
-				State = 1854;
+				State = 1857;
 				expression_pair();
-				State = 1859;
+				State = 1862;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,246,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,247,Context);
 				while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 					if ( _alt==1 ) {
 						{
 						{
-						State = 1855;
+						State = 1858;
 						Match(COMMA);
-						State = 1856;
+						State = 1859;
 						expression_pair();
 						}
 						} 
 					}
-					State = 1861;
+					State = 1864;
 					ErrorHandler.Sync(this);
-					_alt = Interpreter.AdaptivePredict(TokenStream,246,Context);
+					_alt = Interpreter.AdaptivePredict(TokenStream,247,Context);
 				}
-				State = 1863;
+				State = 1866;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==COMMA) {
 					{
-					State = 1862;
+					State = 1865;
 					Match(COMMA);
 					}
 				}
@@ -12527,7 +12541,7 @@ public partial class BooParser : Parser {
 				}
 				break;
 			}
-			State = 1867;
+			State = 1870;
 			Match(RBRACE);
 			}
 		}
@@ -12570,11 +12584,11 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1869;
+			State = 1872;
 			expression();
-			State = 1870;
+			State = 1873;
 			Match(COLON);
-			State = 1871;
+			State = 1874;
 			expression();
 			}
 		}
@@ -12611,7 +12625,7 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1873;
+			State = 1876;
 			Match(RE_LITERAL);
 			}
 		}
@@ -12649,31 +12663,31 @@ public partial class BooParser : Parser {
 		EnterRule(_localctx, 320, RULE_double_literal);
 		int _la;
 		try {
-			State = 1880;
+			State = 1883;
 			ErrorHandler.Sync(this);
 			switch (TokenStream.LA(1)) {
 			case DOUBLE:
 			case SUBTRACT:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1876;
+				State = 1879;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				if (_la==SUBTRACT) {
 					{
-					State = 1875;
+					State = 1878;
 					Match(SUBTRACT);
 					}
 				}
 
-				State = 1878;
+				State = 1881;
 				Match(DOUBLE);
 				}
 				break;
 			case FLOAT:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1879;
+				State = 1882;
 				Match(FLOAT);
 				}
 				break;
@@ -12716,17 +12730,17 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1883;
+			State = 1886;
 			ErrorHandler.Sync(this);
 			_la = TokenStream.LA(1);
 			if (_la==SUBTRACT) {
 				{
-				State = 1882;
+				State = 1885;
 				Match(SUBTRACT);
 				}
 			}
 
-			State = 1885;
+			State = 1888;
 			Match(TIMESPAN);
 			}
 		}
@@ -12773,26 +12787,26 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1895;
+			State = 1898;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,253,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,254,Context) ) {
 			case 1:
 				{
-				State = 1887;
+				State = 1890;
 				expression();
-				State = 1892;
+				State = 1895;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					State = 1888;
+					State = 1891;
 					Match(COMMA);
-					State = 1889;
+					State = 1892;
 					expression();
 					}
 					}
-					State = 1894;
+					State = 1897;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
@@ -12844,26 +12858,26 @@ public partial class BooParser : Parser {
 		try {
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1905;
+			State = 1908;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,255,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,256,Context) ) {
 			case 1:
 				{
-				State = 1897;
+				State = 1900;
 				argument();
-				State = 1902;
+				State = 1905;
 				ErrorHandler.Sync(this);
 				_la = TokenStream.LA(1);
 				while (_la==COMMA) {
 					{
 					{
-					State = 1898;
+					State = 1901;
 					Match(COMMA);
-					State = 1899;
+					State = 1902;
 					argument();
 					}
 					}
-					State = 1904;
+					State = 1907;
 					ErrorHandler.Sync(this);
 					_la = TokenStream.LA(1);
 				}
@@ -12908,20 +12922,20 @@ public partial class BooParser : Parser {
 		ArgumentContext _localctx = new ArgumentContext(Context, State);
 		EnterRule(_localctx, 328, RULE_argument);
 		try {
-			State = 1909;
+			State = 1912;
 			ErrorHandler.Sync(this);
-			switch ( Interpreter.AdaptivePredict(TokenStream,256,Context) ) {
+			switch ( Interpreter.AdaptivePredict(TokenStream,257,Context) ) {
 			case 1:
 				EnterOuterAlt(_localctx, 1);
 				{
-				State = 1907;
+				State = 1910;
 				expression_pair();
 				}
 				break;
 			case 2:
 				EnterOuterAlt(_localctx, 2);
 				{
-				State = 1908;
+				State = 1911;
 				expression();
 				}
 				break;
@@ -12973,25 +12987,25 @@ public partial class BooParser : Parser {
 			int _alt;
 			EnterOuterAlt(_localctx, 1);
 			{
-			State = 1911;
+			State = 1914;
 			macro_name();
-			State = 1916;
+			State = 1919;
 			ErrorHandler.Sync(this);
-			_alt = Interpreter.AdaptivePredict(TokenStream,257,Context);
+			_alt = Interpreter.AdaptivePredict(TokenStream,258,Context);
 			while ( _alt!=2 && _alt!=global::Antlr4.Runtime.Atn.ATN.INVALID_ALT_NUMBER ) {
 				if ( _alt==1 ) {
 					{
 					{
-					State = 1912;
+					State = 1915;
 					Match(DOT);
-					State = 1913;
+					State = 1916;
 					member();
 					}
 					} 
 				}
-				State = 1918;
+				State = 1921;
 				ErrorHandler.Sync(this);
-				_alt = Interpreter.AdaptivePredict(TokenStream,257,Context);
+				_alt = Interpreter.AdaptivePredict(TokenStream,258,Context);
 			}
 			}
 		}
@@ -13048,7 +13062,7 @@ public partial class BooParser : Parser {
 	}
 
 	private static int[] _serializedATN = {
-		4,1,133,1920,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,
+		4,1,133,1923,2,0,7,0,2,1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,
 		7,7,7,2,8,7,8,2,9,7,9,2,10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,7,14,
 		2,15,7,15,2,16,7,16,2,17,7,17,2,18,7,18,2,19,7,19,2,20,7,20,2,21,7,21,
 		2,22,7,22,2,23,7,23,2,24,7,24,2,25,7,25,2,26,7,26,2,27,7,27,2,28,7,28,
@@ -13080,698 +13094,699 @@ public partial class BooParser : Parser {
 		1,5,1,5,3,5,387,8,5,1,5,1,5,1,6,1,6,1,7,1,7,1,7,1,7,1,7,3,7,398,8,7,1,
 		8,1,8,1,8,1,8,1,8,1,8,3,8,406,8,8,3,8,408,8,8,1,8,1,8,3,8,412,8,8,1,9,
 		1,9,1,9,1,9,1,9,3,9,419,8,9,1,10,1,10,1,10,1,10,1,10,1,11,1,11,1,11,1,
-		11,3,11,430,8,11,1,12,1,12,1,12,1,12,3,12,436,8,12,1,13,1,13,1,13,1,13,
-		3,13,442,8,13,1,13,1,13,1,13,3,13,447,8,13,1,13,1,13,1,13,1,13,1,13,3,
-		13,454,8,13,1,13,1,13,1,13,1,14,1,14,1,14,1,14,1,14,1,14,4,14,465,8,14,
-		11,14,12,14,466,3,14,469,8,14,1,14,1,14,1,15,1,15,3,15,475,8,15,1,16,1,
-		16,1,16,1,16,3,16,481,8,16,1,16,1,16,1,16,1,17,1,17,1,17,1,17,5,17,490,
-		8,17,10,17,12,17,493,9,17,3,17,495,8,17,1,17,1,17,3,17,499,8,17,5,17,501,
-		8,17,10,17,12,17,504,9,17,1,18,1,18,3,18,508,8,18,1,18,1,18,1,18,1,18,
-		3,18,514,8,18,1,19,1,19,1,19,1,19,1,20,1,20,1,20,1,20,1,21,1,21,3,21,526,
-		8,21,1,22,1,22,1,22,1,22,3,22,532,8,22,1,22,1,22,3,22,536,8,22,1,22,1,
-		22,1,22,3,22,541,8,22,1,22,3,22,544,8,22,1,22,1,22,1,22,1,22,3,22,550,
-		8,22,1,22,4,22,553,8,22,11,22,12,22,554,3,22,557,8,22,1,22,1,22,1,23,1,
-		23,1,23,1,23,1,24,1,24,1,24,1,24,1,24,1,24,3,24,571,8,24,1,25,1,25,1,25,
-		1,25,3,25,577,8,25,1,26,1,26,1,26,1,26,3,26,583,8,26,1,26,1,26,3,26,587,
-		8,26,1,26,1,26,1,26,3,26,592,8,26,1,26,3,26,595,8,26,1,26,1,26,1,26,1,
-		26,4,26,601,8,26,11,26,12,26,602,3,26,605,8,26,1,26,1,26,1,27,1,27,1,27,
-		1,27,5,27,613,8,27,10,27,12,27,616,9,27,3,27,618,8,27,1,27,1,27,1,28,1,
-		28,1,28,1,28,3,28,626,8,28,1,28,1,28,3,28,630,8,28,1,28,1,28,1,28,1,28,
-		1,28,3,28,637,8,28,1,28,1,28,1,28,1,28,1,28,3,28,644,8,28,1,28,1,28,1,
-		28,1,28,1,28,3,28,651,8,28,3,28,653,8,28,1,29,1,29,1,29,1,29,1,29,3,29,
-		660,8,29,1,29,1,29,3,29,664,8,29,1,29,1,29,4,29,668,8,29,11,29,12,29,669,
-		1,29,1,29,1,30,1,30,1,30,1,30,3,30,678,8,30,1,31,1,31,1,31,1,31,1,31,1,
-		32,1,32,1,32,1,32,1,32,1,32,1,32,1,33,1,33,1,33,5,33,695,8,33,10,33,12,
-		33,698,9,33,1,33,1,33,3,33,702,8,33,1,33,1,33,1,33,3,33,707,8,33,1,33,
-		1,33,1,34,1,34,3,34,713,8,34,1,34,1,34,1,34,3,34,718,8,34,1,34,1,34,3,
-		34,722,8,34,1,34,1,34,3,34,726,8,34,1,34,1,34,1,34,3,34,731,8,34,1,34,
-		1,34,1,34,1,34,1,34,1,34,3,34,739,8,34,1,34,1,34,1,34,1,34,1,35,3,35,746,
-		8,35,1,35,1,35,1,35,1,35,3,35,752,8,35,1,35,1,35,1,35,1,35,1,35,1,35,1,
-		35,1,35,3,35,762,8,35,1,35,1,35,3,35,766,8,35,1,35,1,35,4,35,770,8,35,
-		11,35,12,35,771,1,35,1,35,1,35,1,35,1,35,1,35,3,35,780,8,35,1,35,1,35,
-		3,35,784,8,35,1,35,1,35,1,35,3,35,789,8,35,1,35,1,35,3,35,793,8,35,1,36,
-		1,36,1,37,1,37,1,37,1,37,1,37,1,37,1,37,3,37,804,8,37,1,38,1,38,3,38,808,
-		8,38,1,39,1,39,1,39,1,39,1,39,3,39,815,8,39,1,40,3,40,818,8,40,1,40,5,
-		40,821,8,40,10,40,12,40,824,9,40,1,41,3,41,827,8,41,1,41,4,41,830,8,41,
-		11,41,12,41,831,1,42,5,42,835,8,42,10,42,12,42,838,9,42,1,43,1,43,1,44,
-		1,44,1,45,1,45,1,45,5,45,847,8,45,10,45,12,45,850,9,45,3,45,852,8,45,1,
-		46,1,46,1,46,1,46,1,46,3,46,859,8,46,1,46,1,46,3,46,863,8,46,1,46,3,46,
-		866,8,46,1,46,1,46,1,46,3,46,871,8,46,1,46,1,46,3,46,875,8,46,3,46,877,
-		8,46,1,47,1,47,1,47,5,47,882,8,47,10,47,12,47,885,9,47,3,47,887,8,47,1,
-		48,1,48,1,48,3,48,892,8,48,1,48,3,48,895,8,48,1,49,1,49,1,49,5,49,900,
-		8,49,10,49,12,49,903,9,49,1,50,1,50,1,50,1,50,1,50,3,50,910,8,50,1,51,
-		1,51,1,51,1,51,3,51,916,8,51,1,51,1,51,3,51,920,8,51,1,52,1,52,1,52,1,
-		52,1,52,1,52,3,52,928,8,52,1,53,1,53,1,53,1,53,3,53,934,8,53,1,53,1,53,
-		1,54,1,54,1,54,5,54,941,8,54,10,54,12,54,944,9,54,1,55,1,55,1,55,1,56,
-		1,56,1,56,1,56,1,56,1,56,3,56,955,8,56,1,56,1,56,1,56,5,56,960,8,56,10,
-		56,12,56,963,9,56,1,56,1,56,1,56,1,56,3,56,969,8,56,1,56,1,56,1,56,1,56,
-		1,56,3,56,976,8,56,1,56,3,56,979,8,56,3,56,981,8,56,1,56,1,56,1,57,5,57,
-		986,8,57,10,57,12,57,989,9,57,1,58,1,58,1,58,3,58,994,8,58,1,59,1,59,1,
-		59,1,60,1,60,1,60,1,60,3,60,1003,8,60,1,60,1,60,1,60,1,61,1,61,1,61,1,
-		61,3,61,1012,8,61,1,61,1,61,1,61,1,62,1,62,3,62,1019,8,62,1,63,1,63,1,
-		63,1,63,1,63,1,63,3,63,1027,8,63,1,64,1,64,1,64,1,64,3,64,1033,8,64,5,
-		64,1035,8,64,10,64,12,64,1038,9,64,1,64,4,64,1041,8,64,11,64,12,64,1042,
-		1,65,1,65,1,65,1,66,1,66,3,66,1050,8,66,1,67,3,67,1053,8,67,1,67,4,67,
-		1056,8,67,11,67,12,67,1057,1,68,1,68,1,69,1,69,1,69,1,69,1,69,1,69,3,69,
-		1068,8,69,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,3,70,
-		1081,8,70,1,70,1,70,3,70,1085,8,70,1,71,1,71,1,72,1,72,1,73,1,73,1,73,
-		1,74,1,74,1,74,1,75,1,75,1,75,1,75,1,75,1,75,1,75,3,75,1104,8,75,3,75,
-		1106,8,75,1,75,1,75,1,76,1,76,3,76,1112,8,76,1,77,1,77,1,77,1,77,1,77,
+		11,3,11,430,8,11,1,12,3,12,433,8,12,1,12,1,12,1,12,1,12,3,12,439,8,12,
+		1,13,1,13,1,13,1,13,3,13,445,8,13,1,13,1,13,1,13,3,13,450,8,13,1,13,1,
+		13,1,13,1,13,1,13,3,13,457,8,13,1,13,1,13,1,13,1,14,1,14,1,14,1,14,1,14,
+		1,14,4,14,468,8,14,11,14,12,14,469,3,14,472,8,14,1,14,1,14,1,15,1,15,3,
+		15,478,8,15,1,16,1,16,1,16,1,16,3,16,484,8,16,1,16,1,16,1,16,1,17,1,17,
+		1,17,1,17,5,17,493,8,17,10,17,12,17,496,9,17,3,17,498,8,17,1,17,1,17,3,
+		17,502,8,17,5,17,504,8,17,10,17,12,17,507,9,17,1,18,1,18,3,18,511,8,18,
+		1,18,1,18,1,18,1,18,3,18,517,8,18,1,19,1,19,1,19,1,19,1,20,1,20,1,20,1,
+		20,1,21,1,21,3,21,529,8,21,1,22,1,22,1,22,1,22,3,22,535,8,22,1,22,1,22,
+		3,22,539,8,22,1,22,1,22,1,22,3,22,544,8,22,1,22,3,22,547,8,22,1,22,1,22,
+		1,22,1,22,3,22,553,8,22,1,22,4,22,556,8,22,11,22,12,22,557,3,22,560,8,
+		22,1,22,1,22,1,23,1,23,1,23,1,23,1,24,1,24,1,24,1,24,1,24,1,24,3,24,574,
+		8,24,1,25,1,25,1,25,1,25,3,25,580,8,25,1,26,1,26,1,26,1,26,3,26,586,8,
+		26,1,26,1,26,3,26,590,8,26,1,26,1,26,1,26,3,26,595,8,26,1,26,3,26,598,
+		8,26,1,26,1,26,1,26,1,26,4,26,604,8,26,11,26,12,26,605,3,26,608,8,26,1,
+		26,1,26,1,27,1,27,1,27,1,27,5,27,616,8,27,10,27,12,27,619,9,27,3,27,621,
+		8,27,1,27,1,27,1,28,1,28,1,28,1,28,3,28,629,8,28,1,28,1,28,3,28,633,8,
+		28,1,28,1,28,1,28,1,28,1,28,3,28,640,8,28,1,28,1,28,1,28,1,28,1,28,3,28,
+		647,8,28,1,28,1,28,1,28,1,28,1,28,3,28,654,8,28,3,28,656,8,28,1,29,1,29,
+		1,29,1,29,1,29,3,29,663,8,29,1,29,1,29,3,29,667,8,29,1,29,1,29,4,29,671,
+		8,29,11,29,12,29,672,1,29,1,29,1,30,1,30,1,30,1,30,3,30,681,8,30,1,31,
+		1,31,1,31,1,31,1,31,1,32,1,32,1,32,1,32,1,32,1,32,1,32,1,33,1,33,1,33,
+		5,33,698,8,33,10,33,12,33,701,9,33,1,33,1,33,3,33,705,8,33,1,33,1,33,1,
+		33,3,33,710,8,33,1,33,1,33,1,34,1,34,3,34,716,8,34,1,34,1,34,1,34,3,34,
+		721,8,34,1,34,1,34,3,34,725,8,34,1,34,1,34,3,34,729,8,34,1,34,1,34,1,34,
+		3,34,734,8,34,1,34,1,34,1,34,1,34,1,34,1,34,3,34,742,8,34,1,34,1,34,1,
+		34,1,34,1,35,3,35,749,8,35,1,35,1,35,1,35,1,35,3,35,755,8,35,1,35,1,35,
+		1,35,1,35,1,35,1,35,1,35,1,35,3,35,765,8,35,1,35,1,35,3,35,769,8,35,1,
+		35,1,35,4,35,773,8,35,11,35,12,35,774,1,35,1,35,1,35,1,35,1,35,1,35,3,
+		35,783,8,35,1,35,1,35,3,35,787,8,35,1,35,1,35,1,35,3,35,792,8,35,1,35,
+		1,35,3,35,796,8,35,1,36,1,36,1,37,1,37,1,37,1,37,1,37,1,37,1,37,3,37,807,
+		8,37,1,38,1,38,3,38,811,8,38,1,39,1,39,1,39,1,39,1,39,3,39,818,8,39,1,
+		40,3,40,821,8,40,1,40,5,40,824,8,40,10,40,12,40,827,9,40,1,41,3,41,830,
+		8,41,1,41,4,41,833,8,41,11,41,12,41,834,1,42,5,42,838,8,42,10,42,12,42,
+		841,9,42,1,43,1,43,1,44,1,44,1,45,1,45,1,45,5,45,850,8,45,10,45,12,45,
+		853,9,45,3,45,855,8,45,1,46,1,46,1,46,1,46,1,46,3,46,862,8,46,1,46,1,46,
+		3,46,866,8,46,1,46,3,46,869,8,46,1,46,1,46,1,46,3,46,874,8,46,1,46,1,46,
+		3,46,878,8,46,3,46,880,8,46,1,47,1,47,1,47,5,47,885,8,47,10,47,12,47,888,
+		9,47,3,47,890,8,47,1,48,1,48,1,48,3,48,895,8,48,1,48,3,48,898,8,48,1,49,
+		1,49,1,49,5,49,903,8,49,10,49,12,49,906,9,49,1,50,1,50,1,50,1,50,1,50,
+		3,50,913,8,50,1,51,1,51,1,51,1,51,3,51,919,8,51,1,51,1,51,3,51,923,8,51,
+		1,52,1,52,1,52,1,52,1,52,1,52,3,52,931,8,52,1,53,1,53,1,53,1,53,3,53,937,
+		8,53,1,53,1,53,1,54,1,54,1,54,5,54,944,8,54,10,54,12,54,947,9,54,1,55,
+		1,55,1,55,1,56,1,56,1,56,1,56,1,56,1,56,3,56,958,8,56,1,56,1,56,1,56,5,
+		56,963,8,56,10,56,12,56,966,9,56,1,56,1,56,1,56,1,56,3,56,972,8,56,1,56,
+		1,56,1,56,1,56,1,56,3,56,979,8,56,1,56,3,56,982,8,56,3,56,984,8,56,1,56,
+		1,56,1,57,5,57,989,8,57,10,57,12,57,992,9,57,1,58,1,58,1,58,3,58,997,8,
+		58,1,59,1,59,1,59,1,60,1,60,1,60,1,60,3,60,1006,8,60,1,60,1,60,1,60,1,
+		61,1,61,1,61,1,61,3,61,1015,8,61,1,61,1,61,1,61,1,62,1,62,3,62,1022,8,
+		62,1,63,1,63,1,63,1,63,1,63,1,63,3,63,1030,8,63,1,64,1,64,1,64,1,64,3,
+		64,1036,8,64,5,64,1038,8,64,10,64,12,64,1041,9,64,1,64,4,64,1044,8,64,
+		11,64,12,64,1045,1,65,1,65,1,65,1,66,1,66,3,66,1053,8,66,1,67,3,67,1056,
+		8,67,1,67,4,67,1059,8,67,11,67,12,67,1060,1,68,1,68,1,69,1,69,1,69,1,69,
+		1,69,1,69,3,69,1071,8,69,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,1,70,
+		1,70,1,70,3,70,1084,8,70,1,70,1,70,3,70,1088,8,70,1,71,1,71,1,72,1,72,
+		1,73,1,73,1,73,1,74,1,74,1,74,1,75,1,75,1,75,1,75,1,75,1,75,1,75,3,75,
+		1107,8,75,3,75,1109,8,75,1,75,1,75,1,76,1,76,3,76,1115,8,76,1,77,1,77,
 		1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,1,77,
-		1,77,1,77,3,77,1135,8,77,1,77,3,77,1138,8,77,1,77,1,77,3,77,1142,8,77,
-		1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,
-		3,78,1158,8,78,3,78,1160,8,78,1,79,1,79,1,79,1,80,1,80,3,80,1167,8,80,
-		1,81,1,81,1,81,1,81,1,81,1,81,1,81,3,81,1176,8,81,1,81,3,81,1179,8,81,
-		3,81,1181,8,81,1,82,1,82,1,83,1,83,1,83,1,83,3,83,1189,8,83,1,83,1,83,
-		1,83,3,83,1194,8,83,5,83,1196,8,83,10,83,12,83,1199,9,83,1,83,1,83,1,84,
-		1,84,1,84,1,84,1,84,1,84,1,84,3,84,1210,8,84,3,84,1212,8,84,1,84,3,84,
-		1215,8,84,1,85,1,85,1,85,5,85,1220,8,85,10,85,12,85,1223,9,85,1,85,1,85,
-		3,85,1227,8,85,1,85,1,85,3,85,1231,8,85,1,86,1,86,3,86,1235,8,86,1,86,
-		1,86,3,86,1239,8,86,1,86,1,86,3,86,1243,8,86,1,86,1,86,1,87,1,87,3,87,
-		1249,8,87,1,88,1,88,1,88,1,88,1,88,1,88,3,88,1257,8,88,1,88,3,88,1260,
-		8,88,1,88,3,88,1263,8,88,1,89,1,89,1,90,1,90,3,90,1269,8,90,1,90,3,90,
-		1272,8,90,1,91,1,91,1,91,1,91,3,91,1278,8,91,1,91,3,91,1281,8,91,1,91,
-		1,91,3,91,1285,8,91,1,91,3,91,1288,8,91,1,92,1,92,3,92,1292,8,92,1,93,
-		1,93,1,94,1,94,1,95,1,95,1,95,1,95,1,96,1,96,1,96,1,96,1,96,1,96,1,96,
-		3,96,1309,8,96,1,96,1,96,3,96,1313,8,96,1,97,1,97,1,97,1,97,1,97,3,97,
-		1320,8,97,1,97,1,97,3,97,1324,8,97,1,98,1,98,1,98,1,98,1,98,1,98,1,98,
-		5,98,1333,8,98,10,98,12,98,1336,9,98,1,98,1,98,3,98,1340,8,98,1,99,1,99,
-		3,99,1344,8,99,1,99,1,99,1,100,1,100,1,100,3,100,1351,8,100,1,100,1,100,
-		1,100,1,101,1,101,1,101,5,101,1359,8,101,10,101,12,101,1362,9,101,1,102,
-		1,102,1,102,3,102,1367,8,102,1,103,1,103,1,103,1,103,5,103,1373,8,103,
-		10,103,12,103,1376,9,103,1,103,3,103,1379,8,103,3,103,1381,8,103,1,104,
-		1,104,1,104,5,104,1386,8,104,10,104,12,104,1389,9,104,1,105,1,105,1,105,
-		1,105,3,105,1395,8,105,1,106,1,106,1,106,5,106,1400,8,106,10,106,12,106,
-		1403,9,106,1,107,1,107,1,107,5,107,1408,8,107,10,107,12,107,1411,9,107,
-		1,108,1,108,1,109,1,109,1,109,1,109,1,109,3,109,1420,8,109,1,109,3,109,
-		1423,8,109,1,109,1,109,1,110,1,110,1,111,4,111,1430,8,111,11,111,12,111,
-		1431,1,111,4,111,1435,8,111,11,111,12,111,1436,1,111,3,111,1440,8,111,
-		1,112,1,112,1,112,3,112,1445,8,112,1,112,1,112,1,112,1,112,3,112,1451,
-		8,112,5,112,1453,8,112,10,112,12,112,1456,9,112,3,112,1458,8,112,1,113,
-		1,113,1,113,1,113,1,113,1,113,1,113,1,113,1,113,3,113,1469,8,113,1,113,
-		3,113,1472,8,113,3,113,1474,8,113,1,114,1,114,1,114,1,114,1,115,1,115,
-		1,115,3,115,1483,8,115,1,116,1,116,1,116,3,116,1488,8,116,1,117,1,117,
-		1,117,1,117,1,117,1,117,1,117,1,117,1,117,3,117,1499,8,117,1,117,1,117,
-		1,117,3,117,1504,8,117,1,118,1,118,5,118,1508,8,118,10,118,12,118,1511,
-		9,118,1,119,1,119,1,119,1,120,1,120,5,120,1518,8,120,10,120,12,120,1521,
-		9,120,1,121,1,121,1,121,1,122,1,122,5,122,1528,8,122,10,122,12,122,1531,
-		9,122,1,123,1,123,1,123,1,124,1,124,5,124,1538,8,124,10,124,12,124,1541,
-		9,124,1,125,1,125,1,125,1,125,1,125,3,125,1548,8,125,1,125,1,125,5,125,
-		1552,8,125,10,125,12,125,1555,9,125,1,126,1,126,1,126,1,126,1,126,1,126,
-		3,126,1563,8,126,3,126,1565,8,126,1,127,1,127,1,127,1,127,1,127,1,127,
-		1,127,1,127,3,127,1575,8,127,1,128,1,128,1,128,1,129,1,129,1,129,1,130,
-		1,130,1,130,3,130,1586,8,130,1,130,1,130,1,131,1,131,1,131,1,131,1,131,
-		1,131,1,131,1,132,1,132,1,132,1,132,1,132,1,133,1,133,3,133,1604,8,133,
-		1,134,1,134,1,134,1,134,1,134,1,134,1,134,1,134,3,134,1614,8,134,1,134,
-		1,134,3,134,1618,8,134,1,135,1,135,1,135,1,135,1,135,1,135,1,135,1,135,
-		5,135,1628,8,135,10,135,12,135,1631,9,135,1,135,3,135,1634,8,135,3,135,
-		1636,8,135,1,135,1,135,1,136,1,136,1,137,1,137,1,137,1,137,1,137,3,137,
-		1647,8,137,1,138,1,138,1,138,3,138,1652,8,138,1,138,1,138,3,138,1656,8,
-		138,3,138,1658,8,138,1,139,1,139,3,139,1662,8,139,1,140,1,140,3,140,1666,
-		8,140,1,141,1,141,1,141,1,141,1,141,1,141,5,141,1674,8,141,10,141,12,141,
-		1677,9,141,3,141,1679,8,141,1,141,1,141,3,141,1683,8,141,1,141,1,141,1,
-		141,1,141,1,141,1,141,3,141,1691,8,141,1,141,3,141,1694,8,141,1,141,1,
-		141,1,141,1,141,5,141,1700,8,141,10,141,12,141,1703,9,141,3,141,1705,8,
-		141,1,141,1,141,3,141,1709,8,141,1,141,1,141,3,141,1713,8,141,3,141,1715,
-		8,141,1,142,1,142,5,142,1719,8,142,10,142,12,142,1722,9,142,1,143,1,143,
-		1,143,1,143,1,144,1,144,1,144,1,144,1,144,1,144,1,144,1,144,1,144,1,144,
-		1,144,1,144,1,144,3,144,1741,8,144,1,145,1,145,1,146,1,146,1,147,1,147,
-		1,148,1,148,1,149,3,149,1752,8,149,1,149,1,149,1,150,1,150,1,150,1,150,
-		1,150,3,150,1761,8,150,1,151,1,151,1,151,1,151,1,151,1,151,1,151,3,151,
-		1770,8,151,1,151,1,151,1,151,1,151,1,151,1,151,3,151,1778,8,151,1,151,
-		1,151,1,151,5,151,1783,8,151,10,151,12,151,1786,9,151,1,151,1,151,1,152,
-		1,152,1,152,1,152,1,152,1,152,3,152,1796,8,152,1,152,1,152,1,152,1,152,
-		1,152,1,152,3,152,1804,8,152,1,152,1,152,1,152,5,152,1809,8,152,10,152,
-		12,152,1812,9,152,1,152,1,152,1,153,1,153,1,153,3,153,1819,8,153,1,153,
-		3,153,1822,8,153,1,153,1,153,1,154,3,154,1827,8,154,1,154,4,154,1830,8,
-		154,11,154,12,154,1831,1,154,3,154,1835,8,154,1,155,1,155,1,155,1,155,
-		1,156,1,156,1,156,5,156,1844,8,156,10,156,12,156,1847,9,156,1,156,3,156,
-		1850,8,156,3,156,1852,8,156,1,157,1,157,1,157,1,157,5,157,1858,8,157,10,
-		157,12,157,1861,9,157,1,157,3,157,1864,8,157,3,157,1866,8,157,1,157,1,
-		157,1,158,1,158,1,158,1,158,1,159,1,159,1,160,3,160,1877,8,160,1,160,1,
-		160,3,160,1881,8,160,1,161,3,161,1884,8,161,1,161,1,161,1,162,1,162,1,
-		162,5,162,1891,8,162,10,162,12,162,1894,9,162,3,162,1896,8,162,1,163,1,
-		163,1,163,5,163,1901,8,163,10,163,12,163,1904,9,163,3,163,1906,8,163,1,
-		164,1,164,3,164,1910,8,164,1,165,1,165,1,165,5,165,1915,8,165,10,165,12,
-		165,1918,9,165,1,165,0,0,166,0,2,4,6,8,10,12,14,16,18,20,22,24,26,28,30,
-		32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,68,70,72,74,76,78,
-		80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,110,112,114,116,118,
-		120,122,124,126,128,130,132,134,136,138,140,142,144,146,148,150,152,154,
-		156,158,160,162,164,166,168,170,172,174,176,178,180,182,184,186,188,190,
-		192,194,196,198,200,202,204,206,208,210,212,214,216,218,220,222,224,226,
-		228,230,232,234,236,238,240,242,244,246,248,250,252,254,256,258,260,262,
-		264,266,268,270,272,274,276,278,280,282,284,286,288,290,292,294,296,298,
-		300,302,304,306,308,310,312,314,316,318,320,322,324,326,328,330,0,22,2,
-		0,6,6,121,121,2,0,15,15,60,60,2,0,57,57,70,70,2,0,85,85,87,87,2,0,86,86,
-		90,90,2,0,32,32,56,56,9,0,7,7,28,28,36,36,42,42,47,47,49,52,59,59,63,63,
-		67,67,2,0,101,101,103,103,2,0,61,61,70,70,3,0,39,39,66,66,68,68,2,0,17,
-		17,19,19,2,0,39,39,66,66,6,0,80,80,82,82,84,84,102,102,107,107,110,110,
-		3,0,79,79,83,83,98,99,3,0,81,81,100,101,104,104,2,0,106,106,109,109,4,
-		0,96,97,99,99,101,101,111,111,1,0,96,97,2,0,72,72,116,116,7,0,25,25,32,
-		32,36,36,50,51,54,54,56,56,69,70,2,0,31,31,64,64,1,0,72,73,2099,0,332,
-		1,0,0,0,2,336,1,0,0,0,4,371,1,0,0,0,6,377,1,0,0,0,8,380,1,0,0,0,10,386,
-		1,0,0,0,12,390,1,0,0,0,14,392,1,0,0,0,16,399,1,0,0,0,18,413,1,0,0,0,20,
-		420,1,0,0,0,22,425,1,0,0,0,24,435,1,0,0,0,26,437,1,0,0,0,28,458,1,0,0,
-		0,30,474,1,0,0,0,32,476,1,0,0,0,34,502,1,0,0,0,36,507,1,0,0,0,38,515,1,
-		0,0,0,40,519,1,0,0,0,42,525,1,0,0,0,44,527,1,0,0,0,46,560,1,0,0,0,48,564,
-		1,0,0,0,50,572,1,0,0,0,52,578,1,0,0,0,54,608,1,0,0,0,56,621,1,0,0,0,58,
-		654,1,0,0,0,60,673,1,0,0,0,62,679,1,0,0,0,64,684,1,0,0,0,66,691,1,0,0,
-		0,68,710,1,0,0,0,70,792,1,0,0,0,72,794,1,0,0,0,74,803,1,0,0,0,76,807,1,
-		0,0,0,78,809,1,0,0,0,80,817,1,0,0,0,82,826,1,0,0,0,84,836,1,0,0,0,86,839,
-		1,0,0,0,88,841,1,0,0,0,90,851,1,0,0,0,92,853,1,0,0,0,94,886,1,0,0,0,96,
-		894,1,0,0,0,98,896,1,0,0,0,100,904,1,0,0,0,102,915,1,0,0,0,104,921,1,0,
-		0,0,106,929,1,0,0,0,108,937,1,0,0,0,110,945,1,0,0,0,112,980,1,0,0,0,114,
-		987,1,0,0,0,116,993,1,0,0,0,118,995,1,0,0,0,120,998,1,0,0,0,122,1007,1,
-		0,0,0,124,1016,1,0,0,0,126,1026,1,0,0,0,128,1028,1,0,0,0,130,1044,1,0,
-		0,0,132,1049,1,0,0,0,134,1052,1,0,0,0,136,1059,1,0,0,0,138,1067,1,0,0,
-		0,140,1069,1,0,0,0,142,1086,1,0,0,0,144,1088,1,0,0,0,146,1090,1,0,0,0,
-		148,1093,1,0,0,0,150,1096,1,0,0,0,152,1111,1,0,0,0,154,1141,1,0,0,0,156,
-		1159,1,0,0,0,158,1161,1,0,0,0,160,1166,1,0,0,0,162,1180,1,0,0,0,164,1182,
-		1,0,0,0,166,1184,1,0,0,0,168,1214,1,0,0,0,170,1216,1,0,0,0,172,1232,1,
-		0,0,0,174,1246,1,0,0,0,176,1250,1,0,0,0,178,1264,1,0,0,0,180,1266,1,0,
-		0,0,182,1273,1,0,0,0,184,1289,1,0,0,0,186,1293,1,0,0,0,188,1295,1,0,0,
-		0,190,1297,1,0,0,0,192,1301,1,0,0,0,194,1314,1,0,0,0,196,1325,1,0,0,0,
-		198,1341,1,0,0,0,200,1347,1,0,0,0,202,1355,1,0,0,0,204,1363,1,0,0,0,206,
-		1380,1,0,0,0,208,1382,1,0,0,0,210,1390,1,0,0,0,212,1396,1,0,0,0,214,1404,
-		1,0,0,0,216,1412,1,0,0,0,218,1414,1,0,0,0,220,1426,1,0,0,0,222,1439,1,
-		0,0,0,224,1457,1,0,0,0,226,1459,1,0,0,0,228,1475,1,0,0,0,230,1482,1,0,
-		0,0,232,1484,1,0,0,0,234,1503,1,0,0,0,236,1505,1,0,0,0,238,1512,1,0,0,
-		0,240,1515,1,0,0,0,242,1522,1,0,0,0,244,1525,1,0,0,0,246,1532,1,0,0,0,
-		248,1535,1,0,0,0,250,1542,1,0,0,0,252,1564,1,0,0,0,254,1574,1,0,0,0,256,
-		1576,1,0,0,0,258,1579,1,0,0,0,260,1582,1,0,0,0,262,1589,1,0,0,0,264,1596,
-		1,0,0,0,266,1603,1,0,0,0,268,1617,1,0,0,0,270,1619,1,0,0,0,272,1639,1,
-		0,0,0,274,1641,1,0,0,0,276,1648,1,0,0,0,278,1661,1,0,0,0,280,1663,1,0,
-		0,0,282,1714,1,0,0,0,284,1716,1,0,0,0,286,1723,1,0,0,0,288,1740,1,0,0,
-		0,290,1742,1,0,0,0,292,1744,1,0,0,0,294,1746,1,0,0,0,296,1748,1,0,0,0,
-		298,1751,1,0,0,0,300,1760,1,0,0,0,302,1762,1,0,0,0,304,1789,1,0,0,0,306,
-		1815,1,0,0,0,308,1826,1,0,0,0,310,1836,1,0,0,0,312,1851,1,0,0,0,314,1853,
-		1,0,0,0,316,1869,1,0,0,0,318,1873,1,0,0,0,320,1880,1,0,0,0,322,1883,1,
-		0,0,0,324,1895,1,0,0,0,326,1905,1,0,0,0,328,1909,1,0,0,0,330,1911,1,0,
-		0,0,332,333,3,2,1,0,333,334,5,0,0,1,334,1,1,0,0,0,335,337,3,8,4,0,336,
-		335,1,0,0,0,336,337,1,0,0,0,337,338,1,0,0,0,338,340,3,6,3,0,339,341,3,
-		8,4,0,340,339,1,0,0,0,340,341,1,0,0,0,341,343,1,0,0,0,342,344,3,20,10,
-		0,343,342,1,0,0,0,343,344,1,0,0,0,344,348,1,0,0,0,345,347,3,10,5,0,346,
-		345,1,0,0,0,347,350,1,0,0,0,348,346,1,0,0,0,348,349,1,0,0,0,349,356,1,
-		0,0,0,350,348,1,0,0,0,351,352,4,1,0,0,352,355,3,4,2,0,353,355,3,22,11,
-		0,354,351,1,0,0,0,354,353,1,0,0,0,355,358,1,0,0,0,356,354,1,0,0,0,356,
-		357,1,0,0,0,357,359,1,0,0,0,358,356,1,0,0,0,359,368,3,80,40,0,360,363,
-		3,40,20,0,361,363,3,38,19,0,362,360,1,0,0,0,362,361,1,0,0,0,363,364,1,
-		0,0,0,364,365,3,8,4,0,365,367,1,0,0,0,366,362,1,0,0,0,367,370,1,0,0,0,
-		368,366,1,0,0,0,368,369,1,0,0,0,369,3,1,0,0,0,370,368,1,0,0,0,371,372,
-		3,140,70,0,372,5,1,0,0,0,373,375,3,304,152,0,374,376,3,8,4,0,375,374,1,
-		0,0,0,375,376,1,0,0,0,376,378,1,0,0,0,377,373,1,0,0,0,377,378,1,0,0,0,
-		378,7,1,0,0,0,379,381,7,0,0,0,380,379,1,0,0,0,381,382,1,0,0,0,382,380,
-		1,0,0,0,382,383,1,0,0,0,383,9,1,0,0,0,384,387,3,16,8,0,385,387,3,18,9,
-		0,386,384,1,0,0,0,386,385,1,0,0,0,387,388,1,0,0,0,388,389,3,8,4,0,389,
-		11,1,0,0,0,390,391,3,330,165,0,391,13,1,0,0,0,392,397,3,12,6,0,393,394,
-		5,85,0,0,394,395,3,324,162,0,395,396,5,86,0,0,396,398,1,0,0,0,397,393,
-		1,0,0,0,397,398,1,0,0,0,398,15,1,0,0,0,399,400,5,34,0,0,400,407,3,14,7,
-		0,401,405,5,29,0,0,402,406,3,330,165,0,403,406,3,302,151,0,404,406,5,116,
-		0,0,405,402,1,0,0,0,405,403,1,0,0,0,405,404,1,0,0,0,406,408,1,0,0,0,407,
-		401,1,0,0,0,407,408,1,0,0,0,408,411,1,0,0,0,409,410,5,9,0,0,410,412,5,
-		70,0,0,411,409,1,0,0,0,411,412,1,0,0,0,412,17,1,0,0,0,413,414,5,29,0,0,
-		414,415,3,12,6,0,415,418,5,34,0,0,416,419,5,101,0,0,417,419,3,324,162,
-		0,418,416,1,0,0,0,418,417,1,0,0,0,419,19,1,0,0,0,420,421,5,41,0,0,421,
-		422,3,330,165,0,422,423,3,8,4,0,423,424,3,6,3,0,424,21,1,0,0,0,425,426,
-		3,34,17,0,426,429,3,84,42,0,427,430,3,24,12,0,428,430,3,68,34,0,429,427,
-		1,0,0,0,429,428,1,0,0,0,430,23,1,0,0,0,431,436,3,44,22,0,432,436,3,52,
-		26,0,433,436,3,28,14,0,434,436,3,26,13,0,435,431,1,0,0,0,435,432,1,0,0,
-		0,435,433,1,0,0,0,435,434,1,0,0,0,436,25,1,0,0,0,437,438,5,12,0,0,438,
-		446,5,70,0,0,439,441,5,87,0,0,440,442,5,45,0,0,441,440,1,0,0,0,441,442,
-		1,0,0,0,442,443,1,0,0,0,443,444,3,98,49,0,444,445,5,90,0,0,445,447,1,0,
-		0,0,446,439,1,0,0,0,446,447,1,0,0,0,447,448,1,0,0,0,448,449,5,85,0,0,449,
-		450,3,90,45,0,450,453,5,86,0,0,451,452,5,9,0,0,452,454,3,112,56,0,453,
-		451,1,0,0,0,453,454,1,0,0,0,454,455,1,0,0,0,455,456,3,8,4,0,456,457,3,
-		6,3,0,457,27,1,0,0,0,458,459,5,24,0,0,459,460,5,70,0,0,460,468,3,120,60,
-		0,461,462,5,48,0,0,462,469,3,8,4,0,463,465,3,30,15,0,464,463,1,0,0,0,465,
-		466,1,0,0,0,466,464,1,0,0,0,466,467,1,0,0,0,467,469,1,0,0,0,468,461,1,
-		0,0,0,468,464,1,0,0,0,469,470,1,0,0,0,470,471,3,124,62,0,471,29,1,0,0,
-		0,472,475,3,32,16,0,473,475,3,46,23,0,474,472,1,0,0,0,474,473,1,0,0,0,
-		475,31,1,0,0,0,476,477,3,34,17,0,477,480,5,70,0,0,478,479,5,102,0,0,479,
-		481,3,76,38,0,480,478,1,0,0,0,480,481,1,0,0,0,481,482,1,0,0,0,482,483,
-		3,8,4,0,483,484,3,6,3,0,484,33,1,0,0,0,485,494,5,87,0,0,486,491,3,36,18,
-		0,487,488,5,113,0,0,488,490,3,36,18,0,489,487,1,0,0,0,490,493,1,0,0,0,
-		491,489,1,0,0,0,491,492,1,0,0,0,492,495,1,0,0,0,493,491,1,0,0,0,494,486,
-		1,0,0,0,494,495,1,0,0,0,495,496,1,0,0,0,496,498,5,90,0,0,497,499,3,8,4,
-		0,498,497,1,0,0,0,498,499,1,0,0,0,499,501,1,0,0,0,500,485,1,0,0,0,501,
-		504,1,0,0,0,502,500,1,0,0,0,502,503,1,0,0,0,503,35,1,0,0,0,504,502,1,0,
-		0,0,505,508,3,330,165,0,506,508,5,63,0,0,507,505,1,0,0,0,507,506,1,0,0,
-		0,508,513,1,0,0,0,509,510,5,85,0,0,510,511,3,326,163,0,511,512,5,86,0,
-		0,512,514,1,0,0,0,513,509,1,0,0,0,513,514,1,0,0,0,514,37,1,0,0,0,515,516,
-		5,88,0,0,516,517,3,36,18,0,517,518,5,90,0,0,518,39,1,0,0,0,519,520,5,89,
-		0,0,520,521,3,36,18,0,521,522,5,90,0,0,522,41,1,0,0,0,523,526,3,46,23,
-		0,524,526,3,48,24,0,525,523,1,0,0,0,525,524,1,0,0,0,526,43,1,0,0,0,527,
-		531,7,1,0,0,528,532,5,70,0,0,529,530,5,93,0,0,530,532,3,254,127,0,531,
-		528,1,0,0,0,531,529,1,0,0,0,532,540,1,0,0,0,533,535,5,87,0,0,534,536,5,
-		45,0,0,535,534,1,0,0,0,535,536,1,0,0,0,536,537,1,0,0,0,537,538,3,98,49,
-		0,538,539,5,90,0,0,539,541,1,0,0,0,540,533,1,0,0,0,540,541,1,0,0,0,541,
-		543,1,0,0,0,542,544,3,54,27,0,543,542,1,0,0,0,543,544,1,0,0,0,544,545,
-		1,0,0,0,545,556,3,120,60,0,546,547,5,48,0,0,547,557,3,8,4,0,548,550,3,
-		8,4,0,549,548,1,0,0,0,549,550,1,0,0,0,550,552,1,0,0,0,551,553,3,42,21,
-		0,552,551,1,0,0,0,553,554,1,0,0,0,554,552,1,0,0,0,554,555,1,0,0,0,555,
-		557,1,0,0,0,556,546,1,0,0,0,556,549,1,0,0,0,557,558,1,0,0,0,558,559,3,
-		124,62,0,559,45,1,0,0,0,560,561,5,93,0,0,561,562,3,254,127,0,562,563,3,
-		8,4,0,563,47,1,0,0,0,564,565,3,34,17,0,565,570,3,84,42,0,566,571,3,68,
-		34,0,567,571,3,64,32,0,568,571,3,70,35,0,569,571,3,24,12,0,570,566,1,0,
-		0,0,570,567,1,0,0,0,570,568,1,0,0,0,570,569,1,0,0,0,571,49,1,0,0,0,572,
-		576,3,34,17,0,573,577,3,56,28,0,574,577,3,64,32,0,575,577,3,58,29,0,576,
-		573,1,0,0,0,576,574,1,0,0,0,576,575,1,0,0,0,577,51,1,0,0,0,578,582,5,35,
-		0,0,579,583,5,70,0,0,580,581,5,93,0,0,581,583,3,254,127,0,582,579,1,0,
-		0,0,582,580,1,0,0,0,583,591,1,0,0,0,584,586,5,87,0,0,585,587,5,45,0,0,
-		586,585,1,0,0,0,586,587,1,0,0,0,587,588,1,0,0,0,588,589,3,98,49,0,589,
-		590,5,90,0,0,590,592,1,0,0,0,591,584,1,0,0,0,591,592,1,0,0,0,592,594,1,
-		0,0,0,593,595,3,54,27,0,594,593,1,0,0,0,594,595,1,0,0,0,595,596,1,0,0,
-		0,596,604,3,120,60,0,597,598,5,48,0,0,598,605,3,8,4,0,599,601,3,50,25,
-		0,600,599,1,0,0,0,601,602,1,0,0,0,602,600,1,0,0,0,602,603,1,0,0,0,603,
-		605,1,0,0,0,604,597,1,0,0,0,604,600,1,0,0,0,605,606,1,0,0,0,606,607,3,
-		124,62,0,607,53,1,0,0,0,608,617,5,85,0,0,609,614,3,112,56,0,610,611,5,
-		113,0,0,611,613,3,112,56,0,612,610,1,0,0,0,613,616,1,0,0,0,614,612,1,0,
-		0,0,614,615,1,0,0,0,615,618,1,0,0,0,616,614,1,0,0,0,617,609,1,0,0,0,617,
-		618,1,0,0,0,618,619,1,0,0,0,619,620,5,86,0,0,620,55,1,0,0,0,621,625,5,
-		17,0,0,622,626,3,272,136,0,623,624,5,93,0,0,624,626,3,254,127,0,625,622,
-		1,0,0,0,625,623,1,0,0,0,626,636,1,0,0,0,627,629,5,87,0,0,628,630,5,45,
-		0,0,629,628,1,0,0,0,629,630,1,0,0,0,630,631,1,0,0,0,631,632,3,98,49,0,
-		632,633,5,90,0,0,633,637,1,0,0,0,634,635,5,45,0,0,635,637,3,100,50,0,636,
-		627,1,0,0,0,636,634,1,0,0,0,636,637,1,0,0,0,637,638,1,0,0,0,638,639,5,
-		85,0,0,639,640,3,90,45,0,640,643,5,86,0,0,641,642,5,9,0,0,642,644,3,112,
-		56,0,643,641,1,0,0,0,643,644,1,0,0,0,644,652,1,0,0,0,645,646,3,8,4,0,646,
-		647,3,6,3,0,647,653,1,0,0,0,648,650,3,62,31,0,649,651,3,8,4,0,650,649,
-		1,0,0,0,650,651,1,0,0,0,651,653,1,0,0,0,652,645,1,0,0,0,652,648,1,0,0,
-		0,653,57,1,0,0,0,654,659,7,2,0,0,655,656,7,3,0,0,656,657,3,90,45,0,657,
-		658,7,4,0,0,658,660,1,0,0,0,659,655,1,0,0,0,659,660,1,0,0,0,660,663,1,
-		0,0,0,661,662,5,9,0,0,662,664,3,112,56,0,663,661,1,0,0,0,663,664,1,0,0,
-		0,664,665,1,0,0,0,665,667,3,120,60,0,666,668,3,60,30,0,667,666,1,0,0,0,
-		668,669,1,0,0,0,669,667,1,0,0,0,669,670,1,0,0,0,670,671,1,0,0,0,671,672,
-		3,124,62,0,672,59,1,0,0,0,673,674,3,34,17,0,674,677,7,5,0,0,675,678,3,
-		8,4,0,676,678,3,62,31,0,677,675,1,0,0,0,677,676,1,0,0,0,678,61,1,0,0,0,
-		679,680,3,118,59,0,680,681,5,48,0,0,681,682,3,8,4,0,682,683,3,124,62,0,
-		683,63,1,0,0,0,684,685,5,25,0,0,685,686,5,70,0,0,686,687,5,9,0,0,687,688,
-		3,112,56,0,688,689,3,8,4,0,689,690,3,6,3,0,690,65,1,0,0,0,691,696,5,70,
-		0,0,692,693,5,77,0,0,693,695,5,70,0,0,694,692,1,0,0,0,695,698,1,0,0,0,
-		696,694,1,0,0,0,696,697,1,0,0,0,697,706,1,0,0,0,698,696,1,0,0,0,699,701,
-		5,87,0,0,700,702,5,45,0,0,701,700,1,0,0,0,701,702,1,0,0,0,702,703,1,0,
-		0,0,703,704,3,108,54,0,704,705,5,90,0,0,705,707,1,0,0,0,706,699,1,0,0,
-		0,706,707,1,0,0,0,707,708,1,0,0,0,708,709,5,77,0,0,709,67,1,0,0,0,710,
-		721,5,17,0,0,711,713,3,66,33,0,712,711,1,0,0,0,712,713,1,0,0,0,713,717,
-		1,0,0,0,714,718,3,272,136,0,715,716,5,93,0,0,716,718,3,254,127,0,717,714,
-		1,0,0,0,717,715,1,0,0,0,718,722,1,0,0,0,719,722,5,16,0,0,720,722,5,18,
-		0,0,721,712,1,0,0,0,721,719,1,0,0,0,721,720,1,0,0,0,722,730,1,0,0,0,723,
-		725,5,87,0,0,724,726,5,45,0,0,725,724,1,0,0,0,725,726,1,0,0,0,726,727,
-		1,0,0,0,727,728,3,98,49,0,728,729,5,90,0,0,729,731,1,0,0,0,730,723,1,0,
-		0,0,730,731,1,0,0,0,731,732,1,0,0,0,732,733,5,85,0,0,733,734,3,90,45,0,
-		734,735,5,86,0,0,735,738,3,34,17,0,736,737,5,9,0,0,737,739,3,112,56,0,
-		738,736,1,0,0,0,738,739,1,0,0,0,739,740,1,0,0,0,740,741,3,122,61,0,741,
-		742,3,82,41,0,742,743,3,124,62,0,743,69,1,0,0,0,744,746,3,66,33,0,745,
-		744,1,0,0,0,745,746,1,0,0,0,746,751,1,0,0,0,747,752,5,70,0,0,748,749,5,
-		93,0,0,749,752,3,254,127,0,750,752,5,57,0,0,751,747,1,0,0,0,751,748,1,
-		0,0,0,751,750,1,0,0,0,752,761,1,0,0,0,753,754,5,85,0,0,754,755,3,90,45,
-		0,755,756,5,86,0,0,756,762,1,0,0,0,757,758,5,87,0,0,758,759,3,90,45,0,
-		759,760,5,90,0,0,760,762,1,0,0,0,761,753,1,0,0,0,761,757,1,0,0,0,761,762,
-		1,0,0,0,762,765,1,0,0,0,763,764,5,9,0,0,764,766,3,112,56,0,765,763,1,0,
-		0,0,765,766,1,0,0,0,766,767,1,0,0,0,767,769,3,120,60,0,768,770,3,78,39,
-		0,769,768,1,0,0,0,770,771,1,0,0,0,771,769,1,0,0,0,771,772,1,0,0,0,772,
-		773,1,0,0,0,773,774,3,124,62,0,774,793,1,0,0,0,775,793,3,72,36,0,776,780,
-		5,70,0,0,777,778,5,93,0,0,778,780,3,254,127,0,779,776,1,0,0,0,779,777,
-		1,0,0,0,780,783,1,0,0,0,781,782,5,9,0,0,782,784,3,112,56,0,783,781,1,0,
-		0,0,783,784,1,0,0,0,784,788,1,0,0,0,785,786,5,102,0,0,786,789,3,74,37,
-		0,787,789,3,8,4,0,788,785,1,0,0,0,788,787,1,0,0,0,789,790,1,0,0,0,790,
-		791,3,6,3,0,791,793,1,0,0,0,792,745,1,0,0,0,792,775,1,0,0,0,792,779,1,
-		0,0,0,793,71,1,0,0,0,794,795,3,140,70,0,795,73,1,0,0,0,796,797,3,284,142,
-		0,797,798,3,216,108,0,798,804,1,0,0,0,799,800,3,206,103,0,800,801,3,8,
-		4,0,801,804,1,0,0,0,802,804,3,168,84,0,803,796,1,0,0,0,803,799,1,0,0,0,
-		803,802,1,0,0,0,804,75,1,0,0,0,805,808,3,206,103,0,806,808,3,168,84,0,
-		807,805,1,0,0,0,807,806,1,0,0,0,808,77,1,0,0,0,809,810,3,34,17,0,810,811,
-		3,84,42,0,811,814,7,5,0,0,812,815,3,8,4,0,813,815,3,126,63,0,814,812,1,
-		0,0,0,814,813,1,0,0,0,815,79,1,0,0,0,816,818,3,8,4,0,817,816,1,0,0,0,817,
-		818,1,0,0,0,818,822,1,0,0,0,819,821,3,152,76,0,820,819,1,0,0,0,821,824,
-		1,0,0,0,822,820,1,0,0,0,822,823,1,0,0,0,823,81,1,0,0,0,824,822,1,0,0,0,
-		825,827,3,8,4,0,826,825,1,0,0,0,826,827,1,0,0,0,827,829,1,0,0,0,828,830,
-		3,152,76,0,829,828,1,0,0,0,830,831,1,0,0,0,831,829,1,0,0,0,831,832,1,0,
-		0,0,832,83,1,0,0,0,833,835,3,86,43,0,834,833,1,0,0,0,835,838,1,0,0,0,836,
-		834,1,0,0,0,836,837,1,0,0,0,837,85,1,0,0,0,838,836,1,0,0,0,839,840,7,6,
-		0,0,840,87,1,0,0,0,841,842,5,54,0,0,842,89,1,0,0,0,843,848,3,92,46,0,844,
-		845,5,113,0,0,845,847,3,92,46,0,846,844,1,0,0,0,847,850,1,0,0,0,848,846,
-		1,0,0,0,848,849,1,0,0,0,849,852,1,0,0,0,850,848,1,0,0,0,851,843,1,0,0,
-		0,851,852,1,0,0,0,852,91,1,0,0,0,853,876,3,34,17,0,854,858,5,101,0,0,855,
-		859,5,70,0,0,856,857,5,93,0,0,857,859,3,254,127,0,858,855,1,0,0,0,858,
-		856,1,0,0,0,859,862,1,0,0,0,860,861,5,9,0,0,861,863,3,106,53,0,862,860,
-		1,0,0,0,862,863,1,0,0,0,863,877,1,0,0,0,864,866,3,88,44,0,865,864,1,0,
-		0,0,865,866,1,0,0,0,866,870,1,0,0,0,867,871,5,70,0,0,868,869,5,93,0,0,
-		869,871,3,254,127,0,870,867,1,0,0,0,870,868,1,0,0,0,871,874,1,0,0,0,872,
-		873,5,9,0,0,873,875,3,112,56,0,874,872,1,0,0,0,874,875,1,0,0,0,875,877,
-		1,0,0,0,876,854,1,0,0,0,876,865,1,0,0,0,877,93,1,0,0,0,878,883,3,96,48,
-		0,879,880,5,113,0,0,880,882,3,96,48,0,881,879,1,0,0,0,882,885,1,0,0,0,
-		883,881,1,0,0,0,883,884,1,0,0,0,884,887,1,0,0,0,885,883,1,0,0,0,886,878,
-		1,0,0,0,886,887,1,0,0,0,887,95,1,0,0,0,888,889,5,101,0,0,889,895,3,112,
-		56,0,890,892,3,88,44,0,891,890,1,0,0,0,891,892,1,0,0,0,892,893,1,0,0,0,
-		893,895,3,112,56,0,894,888,1,0,0,0,894,891,1,0,0,0,895,97,1,0,0,0,896,
-		901,3,100,50,0,897,898,5,113,0,0,898,900,3,100,50,0,899,897,1,0,0,0,900,
-		903,1,0,0,0,901,899,1,0,0,0,901,902,1,0,0,0,902,99,1,0,0,0,903,901,1,0,
-		0,0,904,909,5,70,0,0,905,906,5,85,0,0,906,907,3,102,51,0,907,908,5,86,
-		0,0,908,910,1,0,0,0,909,905,1,0,0,0,909,910,1,0,0,0,910,101,1,0,0,0,911,
-		916,5,15,0,0,912,916,5,60,0,0,913,916,5,16,0,0,914,916,3,112,56,0,915,
-		911,1,0,0,0,915,912,1,0,0,0,915,913,1,0,0,0,915,914,1,0,0,0,916,919,1,
-		0,0,0,917,918,5,113,0,0,918,920,3,102,51,0,919,917,1,0,0,0,919,920,1,0,
-		0,0,920,103,1,0,0,0,921,922,5,12,0,0,922,923,5,85,0,0,923,924,3,94,47,
-		0,924,927,5,86,0,0,925,926,5,9,0,0,926,928,3,112,56,0,927,925,1,0,0,0,
-		927,928,1,0,0,0,928,105,1,0,0,0,929,930,5,85,0,0,930,933,3,112,56,0,931,
-		932,5,113,0,0,932,934,3,298,149,0,933,931,1,0,0,0,933,934,1,0,0,0,934,
-		935,1,0,0,0,935,936,5,86,0,0,936,107,1,0,0,0,937,942,3,112,56,0,938,939,
-		5,113,0,0,939,941,3,112,56,0,940,938,1,0,0,0,941,944,1,0,0,0,942,940,1,
-		0,0,0,942,943,1,0,0,0,943,109,1,0,0,0,944,942,1,0,0,0,945,946,5,93,0,0,
-		946,947,3,254,127,0,947,111,1,0,0,0,948,981,3,110,55,0,949,981,3,106,53,
-		0,950,981,3,104,52,0,951,975,3,116,58,0,952,954,5,87,0,0,953,955,5,45,
-		0,0,954,953,1,0,0,0,954,955,1,0,0,0,955,968,1,0,0,0,956,961,5,101,0,0,
-		957,958,5,113,0,0,958,960,5,101,0,0,959,957,1,0,0,0,960,963,1,0,0,0,961,
-		959,1,0,0,0,961,962,1,0,0,0,962,964,1,0,0,0,963,961,1,0,0,0,964,969,5,
-		90,0,0,965,966,3,108,54,0,966,967,5,90,0,0,967,969,1,0,0,0,968,956,1,0,
-		0,0,968,965,1,0,0,0,969,976,1,0,0,0,970,971,5,45,0,0,971,976,5,101,0,0,
-		972,973,5,45,0,0,973,976,3,112,56,0,974,976,1,0,0,0,975,952,1,0,0,0,975,
-		970,1,0,0,0,975,972,1,0,0,0,975,974,1,0,0,0,976,978,1,0,0,0,977,979,5,
-		124,0,0,978,977,1,0,0,0,978,979,1,0,0,0,979,981,1,0,0,0,980,948,1,0,0,
-		0,980,949,1,0,0,0,980,950,1,0,0,0,980,951,1,0,0,0,981,982,1,0,0,0,982,
-		983,3,114,57,0,983,113,1,0,0,0,984,986,7,7,0,0,985,984,1,0,0,0,986,989,
-		1,0,0,0,987,985,1,0,0,0,987,988,1,0,0,0,988,115,1,0,0,0,989,987,1,0,0,
-		0,990,994,3,330,165,0,991,994,5,12,0,0,992,994,5,14,0,0,993,990,1,0,0,
-		0,993,991,1,0,0,0,993,992,1,0,0,0,994,117,1,0,0,0,995,996,5,78,0,0,996,
-		997,5,1,0,0,997,119,1,0,0,0,998,1002,5,78,0,0,999,1000,3,8,4,0,1000,1001,
-		3,6,3,0,1001,1003,1,0,0,0,1002,999,1,0,0,0,1002,1003,1,0,0,0,1003,1004,
-		1,0,0,0,1004,1005,5,1,0,0,1005,1006,3,6,3,0,1006,121,1,0,0,0,1007,1011,
-		5,78,0,0,1008,1009,3,8,4,0,1009,1010,3,6,3,0,1010,1012,1,0,0,0,1011,1008,
-		1,0,0,0,1011,1012,1,0,0,0,1012,1013,1,0,0,0,1013,1014,5,1,0,0,1014,1015,
-		3,6,3,0,1015,123,1,0,0,0,1016,1018,5,2,0,0,1017,1019,3,8,4,0,1018,1017,
-		1,0,0,0,1018,1019,1,0,0,0,1019,125,1,0,0,0,1020,1027,3,128,64,0,1021,1022,
-		5,78,0,0,1022,1023,5,1,0,0,1023,1024,3,82,41,0,1024,1025,3,124,62,0,1025,
-		1027,1,0,0,0,1026,1020,1,0,0,0,1026,1021,1,0,0,0,1027,127,1,0,0,0,1028,
-		1029,5,78,0,0,1029,1036,3,156,78,0,1030,1032,5,121,0,0,1031,1033,3,156,
-		78,0,1032,1031,1,0,0,0,1032,1033,1,0,0,0,1033,1035,1,0,0,0,1034,1030,1,
-		0,0,0,1035,1038,1,0,0,0,1036,1034,1,0,0,0,1036,1037,1,0,0,0,1037,1040,
-		1,0,0,0,1038,1036,1,0,0,0,1039,1041,5,6,0,0,1040,1039,1,0,0,0,1041,1042,
-		1,0,0,0,1042,1040,1,0,0,0,1042,1043,1,0,0,0,1043,129,1,0,0,0,1044,1045,
-		3,142,71,0,1045,1046,3,324,162,0,1046,131,1,0,0,0,1047,1050,3,152,76,0,
-		1048,1050,3,136,68,0,1049,1047,1,0,0,0,1049,1048,1,0,0,0,1050,133,1,0,
-		0,0,1051,1053,3,8,4,0,1052,1051,1,0,0,0,1052,1053,1,0,0,0,1053,1055,1,
-		0,0,0,1054,1056,3,132,66,0,1055,1054,1,0,0,0,1056,1057,1,0,0,0,1057,1055,
-		1,0,0,0,1057,1058,1,0,0,0,1058,135,1,0,0,0,1059,1060,3,48,24,0,1060,137,
-		1,0,0,0,1061,1068,3,128,64,0,1062,1063,5,78,0,0,1063,1064,5,1,0,0,1064,
-		1065,3,134,67,0,1065,1066,3,124,62,0,1066,1068,1,0,0,0,1067,1061,1,0,0,
-		0,1067,1062,1,0,0,0,1068,139,1,0,0,0,1069,1070,3,142,71,0,1070,1084,3,
-		324,162,0,1071,1072,3,120,60,0,1072,1073,3,134,67,0,1073,1074,3,124,62,
-		0,1074,1085,1,0,0,0,1075,1085,3,138,69,0,1076,1081,3,8,4,0,1077,1078,3,
-		158,79,0,1078,1079,3,8,4,0,1079,1081,1,0,0,0,1080,1076,1,0,0,0,1080,1077,
-		1,0,0,0,1081,1082,1,0,0,0,1082,1083,3,6,3,0,1083,1085,1,0,0,0,1084,1071,
-		1,0,0,0,1084,1075,1,0,0,0,1084,1080,1,0,0,0,1085,141,1,0,0,0,1086,1087,
-		7,8,0,0,1087,143,1,0,0,0,1088,1089,5,48,0,0,1089,145,1,0,0,0,1090,1091,
-		5,33,0,0,1091,1092,5,70,0,0,1092,147,1,0,0,0,1093,1094,5,78,0,0,1094,1095,
-		5,70,0,0,1095,149,1,0,0,0,1096,1097,5,17,0,0,1097,1105,5,70,0,0,1098,1099,
-		5,85,0,0,1099,1100,3,90,45,0,1100,1103,5,86,0,0,1101,1102,5,9,0,0,1102,
-		1104,3,112,56,0,1103,1101,1,0,0,0,1103,1104,1,0,0,0,1104,1106,1,0,0,0,
-		1105,1098,1,0,0,0,1105,1106,1,0,0,0,1106,1107,1,0,0,0,1107,1108,3,126,
-		63,0,1108,151,1,0,0,0,1109,1112,3,150,75,0,1110,1112,3,154,77,0,1111,1109,
-		1,0,0,0,1111,1110,1,0,0,0,1112,153,1,0,0,0,1113,1142,3,192,96,0,1114,1142,
-		3,194,97,0,1115,1142,3,196,98,0,1116,1142,3,190,95,0,1117,1142,3,170,85,
-		0,1118,1119,4,77,1,0,1119,1142,3,140,70,0,1120,1142,3,226,113,0,1121,1142,
-		3,182,91,0,1122,1142,3,198,99,0,1123,1142,3,176,88,0,1124,1125,3,144,72,
-		0,1125,1126,3,8,4,0,1126,1142,1,0,0,0,1127,1135,3,146,73,0,1128,1135,3,
-		148,74,0,1129,1135,3,184,92,0,1130,1135,3,186,93,0,1131,1135,3,188,94,
-		0,1132,1135,3,174,87,0,1133,1135,3,178,89,0,1134,1127,1,0,0,0,1134,1128,
-		1,0,0,0,1134,1129,1,0,0,0,1134,1130,1,0,0,0,1134,1131,1,0,0,0,1134,1132,
-		1,0,0,0,1134,1133,1,0,0,0,1135,1137,1,0,0,0,1136,1138,3,158,79,0,1137,
-		1136,1,0,0,0,1137,1138,1,0,0,0,1138,1139,1,0,0,0,1139,1140,3,8,4,0,1140,
-		1142,1,0,0,0,1141,1113,1,0,0,0,1141,1114,1,0,0,0,1141,1115,1,0,0,0,1141,
-		1116,1,0,0,0,1141,1117,1,0,0,0,1141,1118,1,0,0,0,1141,1120,1,0,0,0,1141,
-		1121,1,0,0,0,1141,1122,1,0,0,0,1141,1123,1,0,0,0,1141,1124,1,0,0,0,1141,
-		1134,1,0,0,0,1142,155,1,0,0,0,1143,1144,4,78,2,0,1144,1160,3,130,65,0,
-		1145,1160,3,228,114,0,1146,1160,3,180,90,0,1147,1160,3,200,100,0,1148,
-		1160,3,176,88,0,1149,1160,3,144,72,0,1150,1158,3,146,73,0,1151,1158,3,
-		148,74,0,1152,1158,3,184,92,0,1153,1158,3,186,93,0,1154,1158,3,188,94,
-		0,1155,1158,3,174,87,0,1156,1158,3,178,89,0,1157,1150,1,0,0,0,1157,1151,
-		1,0,0,0,1157,1152,1,0,0,0,1157,1153,1,0,0,0,1157,1154,1,0,0,0,1157,1155,
-		1,0,0,0,1157,1156,1,0,0,0,1158,1160,1,0,0,0,1159,1143,1,0,0,0,1159,1145,
-		1,0,0,0,1159,1146,1,0,0,0,1159,1147,1,0,0,0,1159,1148,1,0,0,0,1159,1149,
-		1,0,0,0,1159,1157,1,0,0,0,1160,157,1,0,0,0,1161,1162,7,9,0,0,1162,1163,
-		3,212,106,0,1163,159,1,0,0,0,1164,1167,3,168,84,0,1165,1167,3,206,103,
-		0,1166,1164,1,0,0,0,1166,1165,1,0,0,0,1167,161,1,0,0,0,1168,1181,3,180,
-		90,0,1169,1176,3,200,100,0,1170,1171,4,81,3,0,1171,1176,3,130,65,0,1172,
-		1176,3,164,82,0,1173,1176,3,174,87,0,1174,1176,3,184,92,0,1175,1169,1,
-		0,0,0,1175,1170,1,0,0,0,1175,1172,1,0,0,0,1175,1173,1,0,0,0,1175,1174,
-		1,0,0,0,1176,1178,1,0,0,0,1177,1179,3,158,79,0,1178,1177,1,0,0,0,1178,
-		1179,1,0,0,0,1179,1181,1,0,0,0,1180,1168,1,0,0,0,1180,1175,1,0,0,0,1181,
-		163,1,0,0,0,1182,1183,3,206,103,0,1183,165,1,0,0,0,1184,1188,5,91,0,0,
-		1185,1186,3,90,45,0,1186,1187,5,79,0,0,1187,1189,1,0,0,0,1188,1185,1,0,
-		0,0,1188,1189,1,0,0,0,1189,1190,1,0,0,0,1190,1197,3,162,81,0,1191,1193,
-		3,8,4,0,1192,1194,3,162,81,0,1193,1192,1,0,0,0,1193,1194,1,0,0,0,1194,
-		1196,1,0,0,0,1195,1191,1,0,0,0,1196,1199,1,0,0,0,1197,1195,1,0,0,0,1197,
-		1198,1,0,0,0,1198,1200,1,0,0,0,1199,1197,1,0,0,0,1200,1201,5,92,0,0,1201,
-		167,1,0,0,0,1202,1215,3,126,63,0,1203,1211,7,10,0,0,1204,1205,5,85,0,0,
-		1205,1206,3,90,45,0,1206,1209,5,86,0,0,1207,1208,5,9,0,0,1208,1210,3,112,
-		56,0,1209,1207,1,0,0,0,1209,1210,1,0,0,0,1210,1212,1,0,0,0,1211,1204,1,
-		0,0,0,1211,1212,1,0,0,0,1212,1213,1,0,0,0,1213,1215,3,126,63,0,1214,1202,
-		1,0,0,0,1214,1203,1,0,0,0,1215,169,1,0,0,0,1216,1217,5,62,0,0,1217,1221,
-		3,126,63,0,1218,1220,3,172,86,0,1219,1218,1,0,0,0,1220,1223,1,0,0,0,1221,
-		1219,1,0,0,0,1221,1222,1,0,0,0,1222,1226,1,0,0,0,1223,1221,1,0,0,0,1224,
-		1225,5,27,0,0,1225,1227,3,126,63,0,1226,1224,1,0,0,0,1226,1227,1,0,0,0,
-		1227,1230,1,0,0,0,1228,1229,5,23,0,0,1229,1231,3,126,63,0,1230,1228,1,
-		0,0,0,1230,1231,1,0,0,0,1231,171,1,0,0,0,1232,1234,5,26,0,0,1233,1235,
-		5,70,0,0,1234,1233,1,0,0,0,1234,1235,1,0,0,0,1235,1238,1,0,0,0,1236,1237,
-		5,9,0,0,1237,1239,3,112,56,0,1238,1236,1,0,0,0,1238,1239,1,0,0,0,1239,
-		1242,1,0,0,0,1240,1241,7,11,0,0,1241,1243,3,212,106,0,1242,1240,1,0,0,
-		0,1242,1243,1,0,0,0,1243,1244,1,0,0,0,1244,1245,3,126,63,0,1245,173,1,
-		0,0,0,1246,1248,5,53,0,0,1247,1249,3,208,104,0,1248,1247,1,0,0,0,1248,
-		1249,1,0,0,0,1249,175,1,0,0,0,1250,1251,5,70,0,0,1251,1252,5,9,0,0,1252,
-		1262,3,112,56,0,1253,1256,5,102,0,0,1254,1257,3,74,37,0,1255,1257,3,76,
-		38,0,1256,1254,1,0,0,0,1256,1255,1,0,0,0,1257,1263,1,0,0,0,1258,1260,3,
-		158,79,0,1259,1258,1,0,0,0,1259,1260,1,0,0,0,1260,1261,1,0,0,0,1261,1263,
-		3,8,4,0,1262,1253,1,0,0,0,1262,1259,1,0,0,0,1263,177,1,0,0,0,1264,1265,
-		3,232,116,0,1265,179,1,0,0,0,1266,1268,5,55,0,0,1267,1269,3,206,103,0,
-		1268,1267,1,0,0,0,1268,1269,1,0,0,0,1269,1271,1,0,0,0,1270,1272,3,158,
-		79,0,1271,1270,1,0,0,0,1271,1272,1,0,0,0,1272,181,1,0,0,0,1273,1287,5,
-		55,0,0,1274,1280,3,206,103,0,1275,1281,3,216,108,0,1276,1278,3,158,79,
-		0,1277,1276,1,0,0,0,1277,1278,1,0,0,0,1278,1279,1,0,0,0,1279,1281,3,8,
-		4,0,1280,1275,1,0,0,0,1280,1277,1,0,0,0,1281,1288,1,0,0,0,1282,1288,3,
-		168,84,0,1283,1285,3,158,79,0,1284,1283,1,0,0,0,1284,1285,1,0,0,0,1285,
-		1286,1,0,0,0,1286,1288,3,8,4,0,1287,1274,1,0,0,0,1287,1282,1,0,0,0,1287,
-		1284,1,0,0,0,1288,183,1,0,0,0,1289,1291,5,69,0,0,1290,1292,3,206,103,0,
-		1291,1290,1,0,0,0,1291,1292,1,0,0,0,1292,185,1,0,0,0,1293,1294,5,10,0,
-		0,1294,187,1,0,0,0,1295,1296,5,11,0,0,1296,189,1,0,0,0,1297,1298,5,66,
-		0,0,1298,1299,3,208,104,0,1299,1300,3,126,63,0,1300,191,1,0,0,0,1301,1302,
-		5,30,0,0,1302,1303,3,202,101,0,1303,1304,5,40,0,0,1304,1305,3,206,103,
-		0,1305,1308,3,126,63,0,1306,1307,5,46,0,0,1307,1309,3,126,63,0,1308,1306,
-		1,0,0,0,1308,1309,1,0,0,0,1309,1312,1,0,0,0,1310,1311,5,61,0,0,1311,1313,
-		3,126,63,0,1312,1310,1,0,0,0,1312,1313,1,0,0,0,1313,193,1,0,0,0,1314,1315,
-		5,68,0,0,1315,1316,3,208,104,0,1316,1319,3,126,63,0,1317,1318,5,46,0,0,
-		1318,1320,3,126,63,0,1319,1317,1,0,0,0,1319,1320,1,0,0,0,1320,1323,1,0,
-		0,0,1321,1322,5,61,0,0,1322,1324,3,126,63,0,1323,1321,1,0,0,0,1323,1324,
-		1,0,0,0,1324,195,1,0,0,0,1325,1326,5,39,0,0,1326,1327,3,208,104,0,1327,
-		1334,3,126,63,0,1328,1329,5,20,0,0,1329,1330,3,208,104,0,1330,1331,3,126,
-		63,0,1331,1333,1,0,0,0,1332,1328,1,0,0,0,1333,1336,1,0,0,0,1334,1332,1,
-		0,0,0,1334,1335,1,0,0,0,1335,1339,1,0,0,0,1336,1334,1,0,0,0,1337,1338,
-		5,21,0,0,1338,1340,3,126,63,0,1339,1337,1,0,0,0,1339,1340,1,0,0,0,1340,
-		197,1,0,0,0,1341,1343,3,200,100,0,1342,1344,3,158,79,0,1343,1342,1,0,0,
-		0,1343,1344,1,0,0,0,1344,1345,1,0,0,0,1345,1346,3,8,4,0,1346,199,1,0,0,
-		0,1347,1348,3,204,102,0,1348,1350,5,113,0,0,1349,1351,3,202,101,0,1350,
-		1349,1,0,0,0,1350,1351,1,0,0,0,1351,1352,1,0,0,0,1352,1353,5,102,0,0,1353,
-		1354,3,206,103,0,1354,201,1,0,0,0,1355,1360,3,204,102,0,1356,1357,5,113,
-		0,0,1357,1359,3,204,102,0,1358,1356,1,0,0,0,1359,1362,1,0,0,0,1360,1358,
-		1,0,0,0,1360,1361,1,0,0,0,1361,203,1,0,0,0,1362,1360,1,0,0,0,1363,1366,
-		5,70,0,0,1364,1365,5,9,0,0,1365,1367,3,112,56,0,1366,1364,1,0,0,0,1366,
-		1367,1,0,0,0,1367,205,1,0,0,0,1368,1381,5,113,0,0,1369,1374,3,208,104,
-		0,1370,1371,5,113,0,0,1371,1373,3,208,104,0,1372,1370,1,0,0,0,1373,1376,
-		1,0,0,0,1374,1372,1,0,0,0,1374,1375,1,0,0,0,1375,1378,1,0,0,0,1376,1374,
-		1,0,0,0,1377,1379,5,113,0,0,1378,1377,1,0,0,0,1378,1379,1,0,0,0,1379,1381,
-		1,0,0,0,1380,1368,1,0,0,0,1380,1369,1,0,0,0,1381,207,1,0,0,0,1382,1387,
-		3,212,106,0,1383,1384,5,30,0,0,1384,1386,3,210,105,0,1385,1383,1,0,0,0,
-		1386,1389,1,0,0,0,1387,1385,1,0,0,0,1387,1388,1,0,0,0,1388,209,1,0,0,0,
-		1389,1387,1,0,0,0,1390,1391,3,202,101,0,1391,1392,5,40,0,0,1392,1394,3,
-		212,106,0,1393,1395,3,158,79,0,1394,1393,1,0,0,0,1394,1395,1,0,0,0,1395,
-		211,1,0,0,0,1396,1401,3,214,107,0,1397,1398,5,46,0,0,1398,1400,3,214,107,
-		0,1399,1397,1,0,0,0,1400,1403,1,0,0,0,1401,1399,1,0,0,0,1401,1402,1,0,
-		0,0,1402,213,1,0,0,0,1403,1401,1,0,0,0,1404,1409,3,230,115,0,1405,1406,
-		5,8,0,0,1406,1408,3,230,115,0,1407,1405,1,0,0,0,1408,1411,1,0,0,0,1409,
-		1407,1,0,0,0,1409,1410,1,0,0,0,1410,215,1,0,0,0,1411,1409,1,0,0,0,1412,
-		1413,3,168,84,0,1413,217,1,0,0,0,1414,1422,5,94,0,0,1415,1416,5,1,0,0,
-		1416,1417,3,222,111,0,1417,1419,5,2,0,0,1418,1420,3,8,4,0,1419,1418,1,
-		0,0,0,1419,1420,1,0,0,0,1420,1423,1,0,0,0,1421,1423,3,224,112,0,1422,1415,
-		1,0,0,0,1422,1421,1,0,0,0,1423,1424,1,0,0,0,1424,1425,5,95,0,0,1425,219,
-		1,0,0,0,1426,1427,3,2,1,0,1427,221,1,0,0,0,1428,1430,3,154,77,0,1429,1428,
-		1,0,0,0,1430,1431,1,0,0,0,1431,1429,1,0,0,0,1431,1432,1,0,0,0,1432,1440,
-		1,0,0,0,1433,1435,3,48,24,0,1434,1433,1,0,0,0,1435,1436,1,0,0,0,1436,1434,
-		1,0,0,0,1436,1437,1,0,0,0,1437,1440,1,0,0,0,1438,1440,3,220,110,0,1439,
-		1429,1,0,0,0,1439,1434,1,0,0,0,1439,1438,1,0,0,0,1440,223,1,0,0,0,1441,
-		1444,3,208,104,0,1442,1443,5,78,0,0,1443,1445,3,208,104,0,1444,1442,1,
-		0,0,0,1444,1445,1,0,0,0,1445,1458,1,0,0,0,1446,1458,3,16,8,0,1447,1454,
-		3,162,81,0,1448,1450,3,8,4,0,1449,1451,3,162,81,0,1450,1449,1,0,0,0,1450,
-		1451,1,0,0,0,1451,1453,1,0,0,0,1452,1448,1,0,0,0,1453,1456,1,0,0,0,1454,
-		1452,1,0,0,0,1454,1455,1,0,0,0,1455,1458,1,0,0,0,1456,1454,1,0,0,0,1457,
-		1441,1,0,0,0,1457,1446,1,0,0,0,1457,1447,1,0,0,0,1458,225,1,0,0,0,1459,
-		1473,3,284,142,0,1460,1474,3,216,108,0,1461,1471,5,102,0,0,1462,1468,3,
-		206,103,0,1463,1469,3,216,108,0,1464,1465,3,158,79,0,1465,1466,3,8,4,0,
-		1466,1469,1,0,0,0,1467,1469,3,8,4,0,1468,1463,1,0,0,0,1468,1464,1,0,0,
-		0,1468,1467,1,0,0,0,1469,1472,1,0,0,0,1470,1472,3,168,84,0,1471,1462,1,
-		0,0,0,1471,1470,1,0,0,0,1472,1474,1,0,0,0,1473,1460,1,0,0,0,1473,1461,
-		1,0,0,0,1474,227,1,0,0,0,1475,1476,3,284,142,0,1476,1477,5,102,0,0,1477,
-		1478,3,206,103,0,1478,229,1,0,0,0,1479,1480,5,43,0,0,1480,1483,3,230,115,
-		0,1481,1483,3,232,116,0,1482,1479,1,0,0,0,1482,1481,1,0,0,0,1483,231,1,
-		0,0,0,1484,1487,3,236,118,0,1485,1486,7,12,0,0,1486,1488,3,232,116,0,1487,
-		1485,1,0,0,0,1487,1488,1,0,0,0,1488,233,1,0,0,0,1489,1499,5,112,0,0,1490,
-		1499,5,108,0,0,1491,1499,5,105,0,0,1492,1493,5,37,0,0,1493,1499,5,43,0,
-		0,1494,1499,5,37,0,0,1495,1496,5,43,0,0,1496,1499,5,40,0,0,1497,1499,5,
-		40,0,0,1498,1489,1,0,0,0,1498,1490,1,0,0,0,1498,1491,1,0,0,0,1498,1492,
-		1,0,0,0,1498,1494,1,0,0,0,1498,1495,1,0,0,0,1498,1497,1,0,0,0,1499,1500,
-		1,0,0,0,1500,1504,3,240,120,0,1501,1502,5,38,0,0,1502,1504,3,112,56,0,
-		1503,1498,1,0,0,0,1503,1501,1,0,0,0,1504,235,1,0,0,0,1505,1509,3,240,120,
-		0,1506,1508,3,234,117,0,1507,1506,1,0,0,0,1508,1511,1,0,0,0,1509,1507,
-		1,0,0,0,1509,1510,1,0,0,0,1510,237,1,0,0,0,1511,1509,1,0,0,0,1512,1513,
-		7,13,0,0,1513,1514,3,244,122,0,1514,239,1,0,0,0,1515,1519,3,244,122,0,
-		1516,1518,3,238,119,0,1517,1516,1,0,0,0,1518,1521,1,0,0,0,1519,1517,1,
-		0,0,0,1519,1520,1,0,0,0,1520,241,1,0,0,0,1521,1519,1,0,0,0,1522,1523,7,
-		14,0,0,1523,1524,3,248,124,0,1524,243,1,0,0,0,1525,1529,3,248,124,0,1526,
-		1528,3,242,121,0,1527,1526,1,0,0,0,1528,1531,1,0,0,0,1529,1527,1,0,0,0,
-		1529,1530,1,0,0,0,1530,245,1,0,0,0,1531,1529,1,0,0,0,1532,1533,7,15,0,
-		0,1533,1534,3,250,125,0,1534,247,1,0,0,0,1535,1539,3,250,125,0,1536,1538,
-		3,246,123,0,1537,1536,1,0,0,0,1538,1541,1,0,0,0,1539,1537,1,0,0,0,1539,
-		1540,1,0,0,0,1540,249,1,0,0,0,1541,1539,1,0,0,0,1542,1547,3,252,126,0,
-		1543,1544,5,9,0,0,1544,1548,3,112,56,0,1545,1546,5,13,0,0,1546,1548,3,
-		112,56,0,1547,1543,1,0,0,0,1547,1545,1,0,0,0,1547,1548,1,0,0,0,1548,1553,
-		1,0,0,0,1549,1550,5,103,0,0,1550,1552,3,250,125,0,1551,1549,1,0,0,0,1552,
-		1555,1,0,0,0,1553,1551,1,0,0,0,1553,1554,1,0,0,0,1554,251,1,0,0,0,1555,
-		1553,1,0,0,0,1556,1557,4,126,4,0,1557,1565,3,298,149,0,1558,1559,7,16,
-		0,0,1559,1565,3,252,126,0,1560,1562,3,284,142,0,1561,1563,7,17,0,0,1562,
-		1561,1,0,0,0,1562,1563,1,0,0,0,1563,1565,1,0,0,0,1564,1556,1,0,0,0,1564,
-		1558,1,0,0,0,1564,1560,1,0,0,0,1565,253,1,0,0,0,1566,1575,3,288,144,0,
-		1567,1575,3,260,130,0,1568,1575,3,266,133,0,1569,1575,3,268,134,0,1570,
-		1575,3,262,131,0,1571,1575,3,264,132,0,1572,1575,3,258,129,0,1573,1575,
-		3,256,128,0,1574,1566,1,0,0,0,1574,1567,1,0,0,0,1574,1568,1,0,0,0,1574,
-		1569,1,0,0,0,1574,1570,1,0,0,0,1574,1571,1,0,0,0,1574,1572,1,0,0,0,1574,
-		1573,1,0,0,0,1575,255,1,0,0,0,1576,1577,5,77,0,0,1577,1578,3,272,136,0,
-		1578,257,1,0,0,0,1579,1580,5,93,0,0,1580,1581,3,254,127,0,1581,259,1,0,
-		0,0,1582,1583,5,14,0,0,1583,1585,5,85,0,0,1584,1586,7,18,0,0,1585,1584,
-		1,0,0,0,1585,1586,1,0,0,0,1586,1587,1,0,0,0,1587,1588,5,86,0,0,1588,261,
-		1,0,0,0,1589,1590,5,13,0,0,1590,1591,5,85,0,0,1591,1592,3,112,56,0,1592,
-		1593,5,113,0,0,1593,1594,3,208,104,0,1594,1595,5,86,0,0,1595,263,1,0,0,
-		0,1596,1597,5,65,0,0,1597,1598,5,85,0,0,1598,1599,3,112,56,0,1599,1600,
-		5,86,0,0,1600,265,1,0,0,0,1601,1604,3,142,71,0,1602,1604,5,14,0,0,1603,
-		1601,1,0,0,0,1603,1602,1,0,0,0,1604,267,1,0,0,0,1605,1618,3,270,135,0,
-		1606,1607,5,85,0,0,1607,1613,3,206,103,0,1608,1609,5,39,0,0,1609,1610,
-		3,212,106,0,1610,1611,5,21,0,0,1611,1612,3,206,103,0,1612,1614,1,0,0,0,
-		1613,1608,1,0,0,0,1613,1614,1,0,0,0,1614,1615,1,0,0,0,1615,1616,5,86,0,
-		0,1616,1618,1,0,0,0,1617,1605,1,0,0,0,1617,1606,1,0,0,0,1618,269,1,0,0,
-		0,1619,1620,5,85,0,0,1620,1621,5,45,0,0,1621,1622,3,112,56,0,1622,1635,
-		5,78,0,0,1623,1636,5,113,0,0,1624,1629,3,208,104,0,1625,1626,5,113,0,0,
-		1626,1628,3,208,104,0,1627,1625,1,0,0,0,1628,1631,1,0,0,0,1629,1627,1,
-		0,0,0,1629,1630,1,0,0,0,1630,1633,1,0,0,0,1631,1629,1,0,0,0,1632,1634,
-		5,113,0,0,1633,1632,1,0,0,0,1633,1634,1,0,0,0,1634,1636,1,0,0,0,1635,1623,
-		1,0,0,0,1635,1624,1,0,0,0,1636,1637,1,0,0,0,1637,1638,5,86,0,0,1638,271,
-		1,0,0,0,1639,1640,7,19,0,0,1640,273,1,0,0,0,1641,1646,5,78,0,0,1642,1647,
-		3,208,104,0,1643,1644,5,78,0,0,1644,1647,3,208,104,0,1645,1647,1,0,0,0,
-		1646,1642,1,0,0,0,1646,1643,1,0,0,0,1646,1645,1,0,0,0,1647,275,1,0,0,0,
-		1648,1657,3,208,104,0,1649,1651,5,78,0,0,1650,1652,3,208,104,0,1651,1650,
-		1,0,0,0,1651,1652,1,0,0,0,1652,1655,1,0,0,0,1653,1654,5,78,0,0,1654,1656,
-		3,208,104,0,1655,1653,1,0,0,0,1655,1656,1,0,0,0,1656,1658,1,0,0,0,1657,
-		1649,1,0,0,0,1657,1658,1,0,0,0,1658,277,1,0,0,0,1659,1662,3,274,137,0,
-		1660,1662,3,276,138,0,1661,1659,1,0,0,0,1661,1660,1,0,0,0,1662,279,1,0,
-		0,0,1663,1665,3,254,127,0,1664,1666,5,124,0,0,1665,1664,1,0,0,0,1665,1666,
-		1,0,0,0,1666,281,1,0,0,0,1667,1678,5,87,0,0,1668,1669,5,45,0,0,1669,1679,
-		3,108,54,0,1670,1675,3,278,139,0,1671,1672,5,113,0,0,1672,1674,3,278,139,
-		0,1673,1671,1,0,0,0,1674,1677,1,0,0,0,1675,1673,1,0,0,0,1675,1676,1,0,
-		0,0,1676,1679,1,0,0,0,1677,1675,1,0,0,0,1678,1668,1,0,0,0,1678,1670,1,
-		0,0,0,1679,1680,1,0,0,0,1680,1682,5,90,0,0,1681,1683,5,124,0,0,1682,1681,
-		1,0,0,0,1682,1683,1,0,0,0,1683,1715,1,0,0,0,1684,1685,5,45,0,0,1685,1715,
-		3,112,56,0,1686,1690,5,77,0,0,1687,1691,3,272,136,0,1688,1689,5,93,0,0,
-		1689,1691,3,254,127,0,1690,1687,1,0,0,0,1690,1688,1,0,0,0,1691,1693,1,
-		0,0,0,1692,1694,5,124,0,0,1693,1692,1,0,0,0,1693,1694,1,0,0,0,1694,1715,
-		1,0,0,0,1695,1704,5,85,0,0,1696,1701,3,328,164,0,1697,1698,5,113,0,0,1698,
-		1700,3,328,164,0,1699,1697,1,0,0,0,1700,1703,1,0,0,0,1701,1699,1,0,0,0,
-		1701,1702,1,0,0,0,1702,1705,1,0,0,0,1703,1701,1,0,0,0,1704,1696,1,0,0,
-		0,1704,1705,1,0,0,0,1705,1706,1,0,0,0,1706,1708,5,86,0,0,1707,1709,5,124,
-		0,0,1708,1707,1,0,0,0,1708,1709,1,0,0,0,1709,1712,1,0,0,0,1710,1713,3,
-		314,157,0,1711,1713,3,286,143,0,1712,1710,1,0,0,0,1712,1711,1,0,0,0,1712,
-		1713,1,0,0,0,1713,1715,1,0,0,0,1714,1667,1,0,0,0,1714,1684,1,0,0,0,1714,
-		1686,1,0,0,0,1714,1695,1,0,0,0,1715,283,1,0,0,0,1716,1720,3,280,140,0,
-		1717,1719,3,282,141,0,1718,1717,1,0,0,0,1719,1722,1,0,0,0,1720,1718,1,
-		0,0,0,1720,1721,1,0,0,0,1721,285,1,0,0,0,1722,1720,1,0,0,0,1723,1724,5,
-		91,0,0,1724,1725,3,312,156,0,1725,1726,5,92,0,0,1726,287,1,0,0,0,1727,
-		1741,3,298,149,0,1728,1741,3,300,150,0,1729,1741,3,310,155,0,1730,1741,
-		3,314,157,0,1731,1741,3,166,83,0,1732,1741,3,218,109,0,1733,1741,3,318,
-		159,0,1734,1741,3,296,148,0,1735,1741,3,294,147,0,1736,1741,3,290,145,
-		0,1737,1741,3,292,146,0,1738,1741,3,320,160,0,1739,1741,3,322,161,0,1740,
-		1727,1,0,0,0,1740,1728,1,0,0,0,1740,1729,1,0,0,0,1740,1730,1,0,0,0,1740,
-		1731,1,0,0,0,1740,1732,1,0,0,0,1740,1733,1,0,0,0,1740,1734,1,0,0,0,1740,
-		1735,1,0,0,0,1740,1736,1,0,0,0,1740,1737,1,0,0,0,1740,1738,1,0,0,0,1740,
-		1739,1,0,0,0,1741,289,1,0,0,0,1742,1743,5,57,0,0,1743,291,1,0,0,0,1744,
-		1745,5,58,0,0,1745,293,1,0,0,0,1746,1747,5,44,0,0,1747,295,1,0,0,0,1748,
-		1749,7,20,0,0,1749,297,1,0,0,0,1750,1752,5,99,0,0,1751,1750,1,0,0,0,1751,
-		1752,1,0,0,0,1752,1753,1,0,0,0,1753,1754,7,21,0,0,1754,299,1,0,0,0,1755,
-		1761,3,308,154,0,1756,1761,3,302,151,0,1757,1761,5,116,0,0,1758,1761,3,
-		304,152,0,1759,1761,5,117,0,0,1760,1755,1,0,0,0,1760,1756,1,0,0,0,1760,
-		1757,1,0,0,0,1760,1758,1,0,0,0,1760,1759,1,0,0,0,1761,301,1,0,0,0,1762,
-		1784,5,115,0,0,1763,1783,5,127,0,0,1764,1783,5,126,0,0,1765,1766,5,129,
-		0,0,1766,1769,3,208,104,0,1767,1768,5,78,0,0,1768,1770,5,70,0,0,1769,1767,
-		1,0,0,0,1769,1770,1,0,0,0,1770,1771,1,0,0,0,1771,1772,5,92,0,0,1772,1783,
-		1,0,0,0,1773,1774,5,130,0,0,1774,1777,3,208,104,0,1775,1776,5,78,0,0,1776,
-		1778,5,70,0,0,1777,1775,1,0,0,0,1777,1778,1,0,0,0,1778,1779,1,0,0,0,1779,
-		1780,5,86,0,0,1780,1783,1,0,0,0,1781,1783,5,128,0,0,1782,1763,1,0,0,0,
-		1782,1764,1,0,0,0,1782,1765,1,0,0,0,1782,1773,1,0,0,0,1782,1781,1,0,0,
-		0,1783,1786,1,0,0,0,1784,1782,1,0,0,0,1784,1785,1,0,0,0,1785,1787,1,0,
-		0,0,1786,1784,1,0,0,0,1787,1788,5,131,0,0,1788,303,1,0,0,0,1789,1810,5,
-		114,0,0,1790,1809,5,127,0,0,1791,1792,5,129,0,0,1792,1795,3,208,104,0,
-		1793,1794,5,78,0,0,1794,1796,5,70,0,0,1795,1793,1,0,0,0,1795,1796,1,0,
-		0,0,1796,1797,1,0,0,0,1797,1798,5,92,0,0,1798,1809,1,0,0,0,1799,1800,5,
-		130,0,0,1800,1803,3,208,104,0,1801,1802,5,78,0,0,1802,1804,5,70,0,0,1803,
-		1801,1,0,0,0,1803,1804,1,0,0,0,1804,1805,1,0,0,0,1805,1806,5,86,0,0,1806,
-		1809,1,0,0,0,1807,1809,5,128,0,0,1808,1790,1,0,0,0,1808,1791,1,0,0,0,1808,
-		1799,1,0,0,0,1808,1807,1,0,0,0,1809,1812,1,0,0,0,1810,1808,1,0,0,0,1810,
-		1811,1,0,0,0,1811,1813,1,0,0,0,1812,1810,1,0,0,0,1813,1814,5,125,0,0,1814,
-		305,1,0,0,0,1815,1816,5,5,0,0,1816,1821,3,208,104,0,1817,1819,5,78,0,0,
-		1818,1817,1,0,0,0,1818,1819,1,0,0,0,1819,1820,1,0,0,0,1820,1822,5,70,0,
-		0,1821,1818,1,0,0,0,1821,1822,1,0,0,0,1822,1823,1,0,0,0,1823,1824,5,5,
-		0,0,1824,307,1,0,0,0,1825,1827,5,5,0,0,1826,1825,1,0,0,0,1826,1827,1,0,
-		0,0,1827,1829,1,0,0,0,1828,1830,3,306,153,0,1829,1828,1,0,0,0,1830,1831,
-		1,0,0,0,1831,1829,1,0,0,0,1831,1832,1,0,0,0,1832,1834,1,0,0,0,1833,1835,
-		5,5,0,0,1834,1833,1,0,0,0,1834,1835,1,0,0,0,1835,309,1,0,0,0,1836,1837,
-		5,87,0,0,1837,1838,3,312,156,0,1838,1839,5,90,0,0,1839,311,1,0,0,0,1840,
-		1845,3,208,104,0,1841,1842,5,113,0,0,1842,1844,3,208,104,0,1843,1841,1,
-		0,0,0,1844,1847,1,0,0,0,1845,1843,1,0,0,0,1845,1846,1,0,0,0,1846,1849,
-		1,0,0,0,1847,1845,1,0,0,0,1848,1850,5,113,0,0,1849,1848,1,0,0,0,1849,1850,
-		1,0,0,0,1850,1852,1,0,0,0,1851,1840,1,0,0,0,1851,1852,1,0,0,0,1852,313,
-		1,0,0,0,1853,1865,5,91,0,0,1854,1859,3,316,158,0,1855,1856,5,113,0,0,1856,
-		1858,3,316,158,0,1857,1855,1,0,0,0,1858,1861,1,0,0,0,1859,1857,1,0,0,0,
-		1859,1860,1,0,0,0,1860,1863,1,0,0,0,1861,1859,1,0,0,0,1862,1864,5,113,
-		0,0,1863,1862,1,0,0,0,1863,1864,1,0,0,0,1864,1866,1,0,0,0,1865,1854,1,
-		0,0,0,1865,1866,1,0,0,0,1866,1867,1,0,0,0,1867,1868,5,92,0,0,1868,315,
-		1,0,0,0,1869,1870,3,208,104,0,1870,1871,5,78,0,0,1871,1872,3,208,104,0,
-		1872,317,1,0,0,0,1873,1874,5,123,0,0,1874,319,1,0,0,0,1875,1877,5,99,0,
-		0,1876,1875,1,0,0,0,1876,1877,1,0,0,0,1877,1878,1,0,0,0,1878,1881,5,75,
-		0,0,1879,1881,5,74,0,0,1880,1876,1,0,0,0,1880,1879,1,0,0,0,1881,321,1,
-		0,0,0,1882,1884,5,99,0,0,1883,1882,1,0,0,0,1883,1884,1,0,0,0,1884,1885,
-		1,0,0,0,1885,1886,5,76,0,0,1886,323,1,0,0,0,1887,1892,3,208,104,0,1888,
-		1889,5,113,0,0,1889,1891,3,208,104,0,1890,1888,1,0,0,0,1891,1894,1,0,0,
-		0,1892,1890,1,0,0,0,1892,1893,1,0,0,0,1893,1896,1,0,0,0,1894,1892,1,0,
-		0,0,1895,1887,1,0,0,0,1895,1896,1,0,0,0,1896,325,1,0,0,0,1897,1902,3,328,
-		164,0,1898,1899,5,113,0,0,1899,1901,3,328,164,0,1900,1898,1,0,0,0,1901,
-		1904,1,0,0,0,1902,1900,1,0,0,0,1902,1903,1,0,0,0,1903,1906,1,0,0,0,1904,
-		1902,1,0,0,0,1905,1897,1,0,0,0,1905,1906,1,0,0,0,1906,327,1,0,0,0,1907,
-		1910,3,316,158,0,1908,1910,3,208,104,0,1909,1907,1,0,0,0,1909,1908,1,0,
-		0,0,1910,329,1,0,0,0,1911,1916,3,142,71,0,1912,1913,5,77,0,0,1913,1915,
-		3,272,136,0,1914,1912,1,0,0,0,1915,1918,1,0,0,0,1916,1914,1,0,0,0,1916,
-		1917,1,0,0,0,1917,331,1,0,0,0,1918,1916,1,0,0,0,258,336,340,343,348,354,
-		356,362,368,375,377,382,386,397,405,407,411,418,429,435,441,446,453,466,
-		468,474,480,491,494,498,502,507,513,525,531,535,540,543,549,554,556,570,
-		576,582,586,591,594,602,604,614,617,625,629,636,643,650,652,659,663,669,
-		677,696,701,706,712,717,721,725,730,738,745,751,761,765,771,779,783,788,
-		792,803,807,814,817,822,826,831,836,848,851,858,862,865,870,874,876,883,
-		886,891,894,901,909,915,919,927,933,942,954,961,968,975,978,980,987,993,
-		1002,1011,1018,1026,1032,1036,1042,1049,1052,1057,1067,1080,1084,1103,
-		1105,1111,1134,1137,1141,1157,1159,1166,1175,1178,1180,1188,1193,1197,
-		1209,1211,1214,1221,1226,1230,1234,1238,1242,1248,1256,1259,1262,1268,
-		1271,1277,1280,1284,1287,1291,1308,1312,1319,1323,1334,1339,1343,1350,
-		1360,1366,1374,1378,1380,1387,1394,1401,1409,1419,1422,1431,1436,1439,
-		1444,1450,1454,1457,1468,1471,1473,1482,1487,1498,1503,1509,1519,1529,
-		1539,1547,1553,1562,1564,1574,1585,1603,1613,1617,1629,1633,1635,1646,
-		1651,1655,1657,1661,1665,1675,1678,1682,1690,1693,1701,1704,1708,1712,
-		1714,1720,1740,1751,1760,1769,1777,1782,1784,1795,1803,1808,1810,1818,
-		1821,1826,1831,1834,1845,1849,1851,1859,1863,1865,1876,1880,1883,1892,
-		1895,1902,1905,1909,1916
+		1,77,1,77,1,77,1,77,1,77,3,77,1138,8,77,1,77,3,77,1141,8,77,1,77,1,77,
+		3,77,1145,8,77,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,1,78,
+		1,78,1,78,1,78,3,78,1161,8,78,3,78,1163,8,78,1,79,1,79,1,79,1,80,1,80,
+		3,80,1170,8,80,1,81,1,81,1,81,1,81,1,81,1,81,1,81,3,81,1179,8,81,1,81,
+		3,81,1182,8,81,3,81,1184,8,81,1,82,1,82,1,83,1,83,1,83,1,83,3,83,1192,
+		8,83,1,83,1,83,1,83,3,83,1197,8,83,5,83,1199,8,83,10,83,12,83,1202,9,83,
+		1,83,1,83,1,84,1,84,1,84,1,84,1,84,1,84,1,84,3,84,1213,8,84,3,84,1215,
+		8,84,1,84,3,84,1218,8,84,1,85,1,85,1,85,5,85,1223,8,85,10,85,12,85,1226,
+		9,85,1,85,1,85,3,85,1230,8,85,1,85,1,85,3,85,1234,8,85,1,86,1,86,3,86,
+		1238,8,86,1,86,1,86,3,86,1242,8,86,1,86,1,86,3,86,1246,8,86,1,86,1,86,
+		1,87,1,87,3,87,1252,8,87,1,88,1,88,1,88,1,88,1,88,1,88,3,88,1260,8,88,
+		1,88,3,88,1263,8,88,1,88,3,88,1266,8,88,1,89,1,89,1,90,1,90,3,90,1272,
+		8,90,1,90,3,90,1275,8,90,1,91,1,91,1,91,1,91,3,91,1281,8,91,1,91,3,91,
+		1284,8,91,1,91,1,91,3,91,1288,8,91,1,91,3,91,1291,8,91,1,92,1,92,3,92,
+		1295,8,92,1,93,1,93,1,94,1,94,1,95,1,95,1,95,1,95,1,96,1,96,1,96,1,96,
+		1,96,1,96,1,96,3,96,1312,8,96,1,96,1,96,3,96,1316,8,96,1,97,1,97,1,97,
+		1,97,1,97,3,97,1323,8,97,1,97,1,97,3,97,1327,8,97,1,98,1,98,1,98,1,98,
+		1,98,1,98,1,98,5,98,1336,8,98,10,98,12,98,1339,9,98,1,98,1,98,3,98,1343,
+		8,98,1,99,1,99,3,99,1347,8,99,1,99,1,99,1,100,1,100,1,100,3,100,1354,8,
+		100,1,100,1,100,1,100,1,101,1,101,1,101,5,101,1362,8,101,10,101,12,101,
+		1365,9,101,1,102,1,102,1,102,3,102,1370,8,102,1,103,1,103,1,103,1,103,
+		5,103,1376,8,103,10,103,12,103,1379,9,103,1,103,3,103,1382,8,103,3,103,
+		1384,8,103,1,104,1,104,1,104,5,104,1389,8,104,10,104,12,104,1392,9,104,
+		1,105,1,105,1,105,1,105,3,105,1398,8,105,1,106,1,106,1,106,5,106,1403,
+		8,106,10,106,12,106,1406,9,106,1,107,1,107,1,107,5,107,1411,8,107,10,107,
+		12,107,1414,9,107,1,108,1,108,1,109,1,109,1,109,1,109,1,109,3,109,1423,
+		8,109,1,109,3,109,1426,8,109,1,109,1,109,1,110,1,110,1,111,4,111,1433,
+		8,111,11,111,12,111,1434,1,111,4,111,1438,8,111,11,111,12,111,1439,1,111,
+		3,111,1443,8,111,1,112,1,112,1,112,3,112,1448,8,112,1,112,1,112,1,112,
+		1,112,3,112,1454,8,112,5,112,1456,8,112,10,112,12,112,1459,9,112,3,112,
+		1461,8,112,1,113,1,113,1,113,1,113,1,113,1,113,1,113,1,113,1,113,3,113,
+		1472,8,113,1,113,3,113,1475,8,113,3,113,1477,8,113,1,114,1,114,1,114,1,
+		114,1,115,1,115,1,115,3,115,1486,8,115,1,116,1,116,1,116,3,116,1491,8,
+		116,1,117,1,117,1,117,1,117,1,117,1,117,1,117,1,117,1,117,3,117,1502,8,
+		117,1,117,1,117,1,117,3,117,1507,8,117,1,118,1,118,5,118,1511,8,118,10,
+		118,12,118,1514,9,118,1,119,1,119,1,119,1,120,1,120,5,120,1521,8,120,10,
+		120,12,120,1524,9,120,1,121,1,121,1,121,1,122,1,122,5,122,1531,8,122,10,
+		122,12,122,1534,9,122,1,123,1,123,1,123,1,124,1,124,5,124,1541,8,124,10,
+		124,12,124,1544,9,124,1,125,1,125,1,125,1,125,1,125,3,125,1551,8,125,1,
+		125,1,125,5,125,1555,8,125,10,125,12,125,1558,9,125,1,126,1,126,1,126,
+		1,126,1,126,1,126,3,126,1566,8,126,3,126,1568,8,126,1,127,1,127,1,127,
+		1,127,1,127,1,127,1,127,1,127,3,127,1578,8,127,1,128,1,128,1,128,1,129,
+		1,129,1,129,1,130,1,130,1,130,3,130,1589,8,130,1,130,1,130,1,131,1,131,
+		1,131,1,131,1,131,1,131,1,131,1,132,1,132,1,132,1,132,1,132,1,133,1,133,
+		3,133,1607,8,133,1,134,1,134,1,134,1,134,1,134,1,134,1,134,1,134,3,134,
+		1617,8,134,1,134,1,134,3,134,1621,8,134,1,135,1,135,1,135,1,135,1,135,
+		1,135,1,135,1,135,5,135,1631,8,135,10,135,12,135,1634,9,135,1,135,3,135,
+		1637,8,135,3,135,1639,8,135,1,135,1,135,1,136,1,136,1,137,1,137,1,137,
+		1,137,1,137,3,137,1650,8,137,1,138,1,138,1,138,3,138,1655,8,138,1,138,
+		1,138,3,138,1659,8,138,3,138,1661,8,138,1,139,1,139,3,139,1665,8,139,1,
+		140,1,140,3,140,1669,8,140,1,141,1,141,1,141,1,141,1,141,1,141,5,141,1677,
+		8,141,10,141,12,141,1680,9,141,3,141,1682,8,141,1,141,1,141,3,141,1686,
+		8,141,1,141,1,141,1,141,1,141,1,141,1,141,3,141,1694,8,141,1,141,3,141,
+		1697,8,141,1,141,1,141,1,141,1,141,5,141,1703,8,141,10,141,12,141,1706,
+		9,141,3,141,1708,8,141,1,141,1,141,3,141,1712,8,141,1,141,1,141,3,141,
+		1716,8,141,3,141,1718,8,141,1,142,1,142,5,142,1722,8,142,10,142,12,142,
+		1725,9,142,1,143,1,143,1,143,1,143,1,144,1,144,1,144,1,144,1,144,1,144,
+		1,144,1,144,1,144,1,144,1,144,1,144,1,144,3,144,1744,8,144,1,145,1,145,
+		1,146,1,146,1,147,1,147,1,148,1,148,1,149,3,149,1755,8,149,1,149,1,149,
+		1,150,1,150,1,150,1,150,1,150,3,150,1764,8,150,1,151,1,151,1,151,1,151,
+		1,151,1,151,1,151,3,151,1773,8,151,1,151,1,151,1,151,1,151,1,151,1,151,
+		3,151,1781,8,151,1,151,1,151,1,151,5,151,1786,8,151,10,151,12,151,1789,
+		9,151,1,151,1,151,1,152,1,152,1,152,1,152,1,152,1,152,3,152,1799,8,152,
+		1,152,1,152,1,152,1,152,1,152,1,152,3,152,1807,8,152,1,152,1,152,1,152,
+		5,152,1812,8,152,10,152,12,152,1815,9,152,1,152,1,152,1,153,1,153,1,153,
+		3,153,1822,8,153,1,153,3,153,1825,8,153,1,153,1,153,1,154,3,154,1830,8,
+		154,1,154,4,154,1833,8,154,11,154,12,154,1834,1,154,3,154,1838,8,154,1,
+		155,1,155,1,155,1,155,1,156,1,156,1,156,5,156,1847,8,156,10,156,12,156,
+		1850,9,156,1,156,3,156,1853,8,156,3,156,1855,8,156,1,157,1,157,1,157,1,
+		157,5,157,1861,8,157,10,157,12,157,1864,9,157,1,157,3,157,1867,8,157,3,
+		157,1869,8,157,1,157,1,157,1,158,1,158,1,158,1,158,1,159,1,159,1,160,3,
+		160,1880,8,160,1,160,1,160,3,160,1884,8,160,1,161,3,161,1887,8,161,1,161,
+		1,161,1,162,1,162,1,162,5,162,1894,8,162,10,162,12,162,1897,9,162,3,162,
+		1899,8,162,1,163,1,163,1,163,5,163,1904,8,163,10,163,12,163,1907,9,163,
+		3,163,1909,8,163,1,164,1,164,3,164,1913,8,164,1,165,1,165,1,165,5,165,
+		1918,8,165,10,165,12,165,1921,9,165,1,165,0,0,166,0,2,4,6,8,10,12,14,16,
+		18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,
+		66,68,70,72,74,76,78,80,82,84,86,88,90,92,94,96,98,100,102,104,106,108,
+		110,112,114,116,118,120,122,124,126,128,130,132,134,136,138,140,142,144,
+		146,148,150,152,154,156,158,160,162,164,166,168,170,172,174,176,178,180,
+		182,184,186,188,190,192,194,196,198,200,202,204,206,208,210,212,214,216,
+		218,220,222,224,226,228,230,232,234,236,238,240,242,244,246,248,250,252,
+		254,256,258,260,262,264,266,268,270,272,274,276,278,280,282,284,286,288,
+		290,292,294,296,298,300,302,304,306,308,310,312,314,316,318,320,322,324,
+		326,328,330,0,22,2,0,6,6,121,121,2,0,15,15,60,60,2,0,57,57,70,70,2,0,85,
+		85,87,87,2,0,86,86,90,90,2,0,32,32,56,56,9,0,7,7,28,28,36,36,42,42,47,
+		47,49,52,59,59,63,63,67,67,2,0,101,101,103,103,2,0,61,61,70,70,3,0,39,
+		39,66,66,68,68,2,0,17,17,19,19,2,0,39,39,66,66,6,0,80,80,82,82,84,84,102,
+		102,107,107,110,110,3,0,79,79,83,83,98,99,3,0,81,81,100,101,104,104,2,
+		0,106,106,109,109,4,0,96,97,99,99,101,101,111,111,1,0,96,97,2,0,72,72,
+		116,116,7,0,25,25,32,32,36,36,50,51,54,54,56,56,69,70,2,0,31,31,64,64,
+		1,0,72,73,2103,0,332,1,0,0,0,2,336,1,0,0,0,4,371,1,0,0,0,6,377,1,0,0,0,
+		8,380,1,0,0,0,10,386,1,0,0,0,12,390,1,0,0,0,14,392,1,0,0,0,16,399,1,0,
+		0,0,18,413,1,0,0,0,20,420,1,0,0,0,22,425,1,0,0,0,24,432,1,0,0,0,26,440,
+		1,0,0,0,28,461,1,0,0,0,30,477,1,0,0,0,32,479,1,0,0,0,34,505,1,0,0,0,36,
+		510,1,0,0,0,38,518,1,0,0,0,40,522,1,0,0,0,42,528,1,0,0,0,44,530,1,0,0,
+		0,46,563,1,0,0,0,48,567,1,0,0,0,50,575,1,0,0,0,52,581,1,0,0,0,54,611,1,
+		0,0,0,56,624,1,0,0,0,58,657,1,0,0,0,60,676,1,0,0,0,62,682,1,0,0,0,64,687,
+		1,0,0,0,66,694,1,0,0,0,68,713,1,0,0,0,70,795,1,0,0,0,72,797,1,0,0,0,74,
+		806,1,0,0,0,76,810,1,0,0,0,78,812,1,0,0,0,80,820,1,0,0,0,82,829,1,0,0,
+		0,84,839,1,0,0,0,86,842,1,0,0,0,88,844,1,0,0,0,90,854,1,0,0,0,92,856,1,
+		0,0,0,94,889,1,0,0,0,96,897,1,0,0,0,98,899,1,0,0,0,100,907,1,0,0,0,102,
+		918,1,0,0,0,104,924,1,0,0,0,106,932,1,0,0,0,108,940,1,0,0,0,110,948,1,
+		0,0,0,112,983,1,0,0,0,114,990,1,0,0,0,116,996,1,0,0,0,118,998,1,0,0,0,
+		120,1001,1,0,0,0,122,1010,1,0,0,0,124,1019,1,0,0,0,126,1029,1,0,0,0,128,
+		1031,1,0,0,0,130,1047,1,0,0,0,132,1052,1,0,0,0,134,1055,1,0,0,0,136,1062,
+		1,0,0,0,138,1070,1,0,0,0,140,1072,1,0,0,0,142,1089,1,0,0,0,144,1091,1,
+		0,0,0,146,1093,1,0,0,0,148,1096,1,0,0,0,150,1099,1,0,0,0,152,1114,1,0,
+		0,0,154,1144,1,0,0,0,156,1162,1,0,0,0,158,1164,1,0,0,0,160,1169,1,0,0,
+		0,162,1183,1,0,0,0,164,1185,1,0,0,0,166,1187,1,0,0,0,168,1217,1,0,0,0,
+		170,1219,1,0,0,0,172,1235,1,0,0,0,174,1249,1,0,0,0,176,1253,1,0,0,0,178,
+		1267,1,0,0,0,180,1269,1,0,0,0,182,1276,1,0,0,0,184,1292,1,0,0,0,186,1296,
+		1,0,0,0,188,1298,1,0,0,0,190,1300,1,0,0,0,192,1304,1,0,0,0,194,1317,1,
+		0,0,0,196,1328,1,0,0,0,198,1344,1,0,0,0,200,1350,1,0,0,0,202,1358,1,0,
+		0,0,204,1366,1,0,0,0,206,1383,1,0,0,0,208,1385,1,0,0,0,210,1393,1,0,0,
+		0,212,1399,1,0,0,0,214,1407,1,0,0,0,216,1415,1,0,0,0,218,1417,1,0,0,0,
+		220,1429,1,0,0,0,222,1442,1,0,0,0,224,1460,1,0,0,0,226,1462,1,0,0,0,228,
+		1478,1,0,0,0,230,1485,1,0,0,0,232,1487,1,0,0,0,234,1506,1,0,0,0,236,1508,
+		1,0,0,0,238,1515,1,0,0,0,240,1518,1,0,0,0,242,1525,1,0,0,0,244,1528,1,
+		0,0,0,246,1535,1,0,0,0,248,1538,1,0,0,0,250,1545,1,0,0,0,252,1567,1,0,
+		0,0,254,1577,1,0,0,0,256,1579,1,0,0,0,258,1582,1,0,0,0,260,1585,1,0,0,
+		0,262,1592,1,0,0,0,264,1599,1,0,0,0,266,1606,1,0,0,0,268,1620,1,0,0,0,
+		270,1622,1,0,0,0,272,1642,1,0,0,0,274,1644,1,0,0,0,276,1651,1,0,0,0,278,
+		1664,1,0,0,0,280,1666,1,0,0,0,282,1717,1,0,0,0,284,1719,1,0,0,0,286,1726,
+		1,0,0,0,288,1743,1,0,0,0,290,1745,1,0,0,0,292,1747,1,0,0,0,294,1749,1,
+		0,0,0,296,1751,1,0,0,0,298,1754,1,0,0,0,300,1763,1,0,0,0,302,1765,1,0,
+		0,0,304,1792,1,0,0,0,306,1818,1,0,0,0,308,1829,1,0,0,0,310,1839,1,0,0,
+		0,312,1854,1,0,0,0,314,1856,1,0,0,0,316,1872,1,0,0,0,318,1876,1,0,0,0,
+		320,1883,1,0,0,0,322,1886,1,0,0,0,324,1898,1,0,0,0,326,1908,1,0,0,0,328,
+		1912,1,0,0,0,330,1914,1,0,0,0,332,333,3,2,1,0,333,334,5,0,0,1,334,1,1,
+		0,0,0,335,337,3,8,4,0,336,335,1,0,0,0,336,337,1,0,0,0,337,338,1,0,0,0,
+		338,340,3,6,3,0,339,341,3,8,4,0,340,339,1,0,0,0,340,341,1,0,0,0,341,343,
+		1,0,0,0,342,344,3,20,10,0,343,342,1,0,0,0,343,344,1,0,0,0,344,348,1,0,
+		0,0,345,347,3,10,5,0,346,345,1,0,0,0,347,350,1,0,0,0,348,346,1,0,0,0,348,
+		349,1,0,0,0,349,356,1,0,0,0,350,348,1,0,0,0,351,352,4,1,0,0,352,355,3,
+		4,2,0,353,355,3,22,11,0,354,351,1,0,0,0,354,353,1,0,0,0,355,358,1,0,0,
+		0,356,354,1,0,0,0,356,357,1,0,0,0,357,359,1,0,0,0,358,356,1,0,0,0,359,
+		368,3,80,40,0,360,363,3,40,20,0,361,363,3,38,19,0,362,360,1,0,0,0,362,
+		361,1,0,0,0,363,364,1,0,0,0,364,365,3,8,4,0,365,367,1,0,0,0,366,362,1,
+		0,0,0,367,370,1,0,0,0,368,366,1,0,0,0,368,369,1,0,0,0,369,3,1,0,0,0,370,
+		368,1,0,0,0,371,372,3,140,70,0,372,5,1,0,0,0,373,375,3,304,152,0,374,376,
+		3,8,4,0,375,374,1,0,0,0,375,376,1,0,0,0,376,378,1,0,0,0,377,373,1,0,0,
+		0,377,378,1,0,0,0,378,7,1,0,0,0,379,381,7,0,0,0,380,379,1,0,0,0,381,382,
+		1,0,0,0,382,380,1,0,0,0,382,383,1,0,0,0,383,9,1,0,0,0,384,387,3,16,8,0,
+		385,387,3,18,9,0,386,384,1,0,0,0,386,385,1,0,0,0,387,388,1,0,0,0,388,389,
+		3,8,4,0,389,11,1,0,0,0,390,391,3,330,165,0,391,13,1,0,0,0,392,397,3,12,
+		6,0,393,394,5,85,0,0,394,395,3,324,162,0,395,396,5,86,0,0,396,398,1,0,
+		0,0,397,393,1,0,0,0,397,398,1,0,0,0,398,15,1,0,0,0,399,400,5,34,0,0,400,
+		407,3,14,7,0,401,405,5,29,0,0,402,406,3,330,165,0,403,406,3,302,151,0,
+		404,406,5,116,0,0,405,402,1,0,0,0,405,403,1,0,0,0,405,404,1,0,0,0,406,
+		408,1,0,0,0,407,401,1,0,0,0,407,408,1,0,0,0,408,411,1,0,0,0,409,410,5,
+		9,0,0,410,412,5,70,0,0,411,409,1,0,0,0,411,412,1,0,0,0,412,17,1,0,0,0,
+		413,414,5,29,0,0,414,415,3,12,6,0,415,418,5,34,0,0,416,419,5,101,0,0,417,
+		419,3,324,162,0,418,416,1,0,0,0,418,417,1,0,0,0,419,19,1,0,0,0,420,421,
+		5,41,0,0,421,422,3,330,165,0,422,423,3,8,4,0,423,424,3,6,3,0,424,21,1,
+		0,0,0,425,426,3,34,17,0,426,429,3,84,42,0,427,430,3,24,12,0,428,430,3,
+		68,34,0,429,427,1,0,0,0,429,428,1,0,0,0,430,23,1,0,0,0,431,433,5,54,0,
+		0,432,431,1,0,0,0,432,433,1,0,0,0,433,438,1,0,0,0,434,439,3,44,22,0,435,
+		439,3,52,26,0,436,439,3,28,14,0,437,439,3,26,13,0,438,434,1,0,0,0,438,
+		435,1,0,0,0,438,436,1,0,0,0,438,437,1,0,0,0,439,25,1,0,0,0,440,441,5,12,
+		0,0,441,449,5,70,0,0,442,444,5,87,0,0,443,445,5,45,0,0,444,443,1,0,0,0,
+		444,445,1,0,0,0,445,446,1,0,0,0,446,447,3,98,49,0,447,448,5,90,0,0,448,
+		450,1,0,0,0,449,442,1,0,0,0,449,450,1,0,0,0,450,451,1,0,0,0,451,452,5,
+		85,0,0,452,453,3,90,45,0,453,456,5,86,0,0,454,455,5,9,0,0,455,457,3,112,
+		56,0,456,454,1,0,0,0,456,457,1,0,0,0,457,458,1,0,0,0,458,459,3,8,4,0,459,
+		460,3,6,3,0,460,27,1,0,0,0,461,462,5,24,0,0,462,463,5,70,0,0,463,471,3,
+		120,60,0,464,465,5,48,0,0,465,472,3,8,4,0,466,468,3,30,15,0,467,466,1,
+		0,0,0,468,469,1,0,0,0,469,467,1,0,0,0,469,470,1,0,0,0,470,472,1,0,0,0,
+		471,464,1,0,0,0,471,467,1,0,0,0,472,473,1,0,0,0,473,474,3,124,62,0,474,
+		29,1,0,0,0,475,478,3,32,16,0,476,478,3,46,23,0,477,475,1,0,0,0,477,476,
+		1,0,0,0,478,31,1,0,0,0,479,480,3,34,17,0,480,483,5,70,0,0,481,482,5,102,
+		0,0,482,484,3,76,38,0,483,481,1,0,0,0,483,484,1,0,0,0,484,485,1,0,0,0,
+		485,486,3,8,4,0,486,487,3,6,3,0,487,33,1,0,0,0,488,497,5,87,0,0,489,494,
+		3,36,18,0,490,491,5,113,0,0,491,493,3,36,18,0,492,490,1,0,0,0,493,496,
+		1,0,0,0,494,492,1,0,0,0,494,495,1,0,0,0,495,498,1,0,0,0,496,494,1,0,0,
+		0,497,489,1,0,0,0,497,498,1,0,0,0,498,499,1,0,0,0,499,501,5,90,0,0,500,
+		502,3,8,4,0,501,500,1,0,0,0,501,502,1,0,0,0,502,504,1,0,0,0,503,488,1,
+		0,0,0,504,507,1,0,0,0,505,503,1,0,0,0,505,506,1,0,0,0,506,35,1,0,0,0,507,
+		505,1,0,0,0,508,511,3,330,165,0,509,511,5,63,0,0,510,508,1,0,0,0,510,509,
+		1,0,0,0,511,516,1,0,0,0,512,513,5,85,0,0,513,514,3,326,163,0,514,515,5,
+		86,0,0,515,517,1,0,0,0,516,512,1,0,0,0,516,517,1,0,0,0,517,37,1,0,0,0,
+		518,519,5,88,0,0,519,520,3,36,18,0,520,521,5,90,0,0,521,39,1,0,0,0,522,
+		523,5,89,0,0,523,524,3,36,18,0,524,525,5,90,0,0,525,41,1,0,0,0,526,529,
+		3,46,23,0,527,529,3,48,24,0,528,526,1,0,0,0,528,527,1,0,0,0,529,43,1,0,
+		0,0,530,534,7,1,0,0,531,535,5,70,0,0,532,533,5,93,0,0,533,535,3,254,127,
+		0,534,531,1,0,0,0,534,532,1,0,0,0,535,543,1,0,0,0,536,538,5,87,0,0,537,
+		539,5,45,0,0,538,537,1,0,0,0,538,539,1,0,0,0,539,540,1,0,0,0,540,541,3,
+		98,49,0,541,542,5,90,0,0,542,544,1,0,0,0,543,536,1,0,0,0,543,544,1,0,0,
+		0,544,546,1,0,0,0,545,547,3,54,27,0,546,545,1,0,0,0,546,547,1,0,0,0,547,
+		548,1,0,0,0,548,559,3,120,60,0,549,550,5,48,0,0,550,560,3,8,4,0,551,553,
+		3,8,4,0,552,551,1,0,0,0,552,553,1,0,0,0,553,555,1,0,0,0,554,556,3,42,21,
+		0,555,554,1,0,0,0,556,557,1,0,0,0,557,555,1,0,0,0,557,558,1,0,0,0,558,
+		560,1,0,0,0,559,549,1,0,0,0,559,552,1,0,0,0,560,561,1,0,0,0,561,562,3,
+		124,62,0,562,45,1,0,0,0,563,564,5,93,0,0,564,565,3,254,127,0,565,566,3,
+		8,4,0,566,47,1,0,0,0,567,568,3,34,17,0,568,573,3,84,42,0,569,574,3,68,
+		34,0,570,574,3,64,32,0,571,574,3,70,35,0,572,574,3,24,12,0,573,569,1,0,
+		0,0,573,570,1,0,0,0,573,571,1,0,0,0,573,572,1,0,0,0,574,49,1,0,0,0,575,
+		579,3,34,17,0,576,580,3,56,28,0,577,580,3,64,32,0,578,580,3,58,29,0,579,
+		576,1,0,0,0,579,577,1,0,0,0,579,578,1,0,0,0,580,51,1,0,0,0,581,585,5,35,
+		0,0,582,586,5,70,0,0,583,584,5,93,0,0,584,586,3,254,127,0,585,582,1,0,
+		0,0,585,583,1,0,0,0,586,594,1,0,0,0,587,589,5,87,0,0,588,590,5,45,0,0,
+		589,588,1,0,0,0,589,590,1,0,0,0,590,591,1,0,0,0,591,592,3,98,49,0,592,
+		593,5,90,0,0,593,595,1,0,0,0,594,587,1,0,0,0,594,595,1,0,0,0,595,597,1,
+		0,0,0,596,598,3,54,27,0,597,596,1,0,0,0,597,598,1,0,0,0,598,599,1,0,0,
+		0,599,607,3,120,60,0,600,601,5,48,0,0,601,608,3,8,4,0,602,604,3,50,25,
+		0,603,602,1,0,0,0,604,605,1,0,0,0,605,603,1,0,0,0,605,606,1,0,0,0,606,
+		608,1,0,0,0,607,600,1,0,0,0,607,603,1,0,0,0,608,609,1,0,0,0,609,610,3,
+		124,62,0,610,53,1,0,0,0,611,620,5,85,0,0,612,617,3,112,56,0,613,614,5,
+		113,0,0,614,616,3,112,56,0,615,613,1,0,0,0,616,619,1,0,0,0,617,615,1,0,
+		0,0,617,618,1,0,0,0,618,621,1,0,0,0,619,617,1,0,0,0,620,612,1,0,0,0,620,
+		621,1,0,0,0,621,622,1,0,0,0,622,623,5,86,0,0,623,55,1,0,0,0,624,628,5,
+		17,0,0,625,629,3,272,136,0,626,627,5,93,0,0,627,629,3,254,127,0,628,625,
+		1,0,0,0,628,626,1,0,0,0,629,639,1,0,0,0,630,632,5,87,0,0,631,633,5,45,
+		0,0,632,631,1,0,0,0,632,633,1,0,0,0,633,634,1,0,0,0,634,635,3,98,49,0,
+		635,636,5,90,0,0,636,640,1,0,0,0,637,638,5,45,0,0,638,640,3,100,50,0,639,
+		630,1,0,0,0,639,637,1,0,0,0,639,640,1,0,0,0,640,641,1,0,0,0,641,642,5,
+		85,0,0,642,643,3,90,45,0,643,646,5,86,0,0,644,645,5,9,0,0,645,647,3,112,
+		56,0,646,644,1,0,0,0,646,647,1,0,0,0,647,655,1,0,0,0,648,649,3,8,4,0,649,
+		650,3,6,3,0,650,656,1,0,0,0,651,653,3,62,31,0,652,654,3,8,4,0,653,652,
+		1,0,0,0,653,654,1,0,0,0,654,656,1,0,0,0,655,648,1,0,0,0,655,651,1,0,0,
+		0,656,57,1,0,0,0,657,662,7,2,0,0,658,659,7,3,0,0,659,660,3,90,45,0,660,
+		661,7,4,0,0,661,663,1,0,0,0,662,658,1,0,0,0,662,663,1,0,0,0,663,666,1,
+		0,0,0,664,665,5,9,0,0,665,667,3,112,56,0,666,664,1,0,0,0,666,667,1,0,0,
+		0,667,668,1,0,0,0,668,670,3,120,60,0,669,671,3,60,30,0,670,669,1,0,0,0,
+		671,672,1,0,0,0,672,670,1,0,0,0,672,673,1,0,0,0,673,674,1,0,0,0,674,675,
+		3,124,62,0,675,59,1,0,0,0,676,677,3,34,17,0,677,680,7,5,0,0,678,681,3,
+		8,4,0,679,681,3,62,31,0,680,678,1,0,0,0,680,679,1,0,0,0,681,61,1,0,0,0,
+		682,683,3,118,59,0,683,684,5,48,0,0,684,685,3,8,4,0,685,686,3,124,62,0,
+		686,63,1,0,0,0,687,688,5,25,0,0,688,689,5,70,0,0,689,690,5,9,0,0,690,691,
+		3,112,56,0,691,692,3,8,4,0,692,693,3,6,3,0,693,65,1,0,0,0,694,699,5,70,
+		0,0,695,696,5,77,0,0,696,698,5,70,0,0,697,695,1,0,0,0,698,701,1,0,0,0,
+		699,697,1,0,0,0,699,700,1,0,0,0,700,709,1,0,0,0,701,699,1,0,0,0,702,704,
+		5,87,0,0,703,705,5,45,0,0,704,703,1,0,0,0,704,705,1,0,0,0,705,706,1,0,
+		0,0,706,707,3,108,54,0,707,708,5,90,0,0,708,710,1,0,0,0,709,702,1,0,0,
+		0,709,710,1,0,0,0,710,711,1,0,0,0,711,712,5,77,0,0,712,67,1,0,0,0,713,
+		724,5,17,0,0,714,716,3,66,33,0,715,714,1,0,0,0,715,716,1,0,0,0,716,720,
+		1,0,0,0,717,721,3,272,136,0,718,719,5,93,0,0,719,721,3,254,127,0,720,717,
+		1,0,0,0,720,718,1,0,0,0,721,725,1,0,0,0,722,725,5,16,0,0,723,725,5,18,
+		0,0,724,715,1,0,0,0,724,722,1,0,0,0,724,723,1,0,0,0,725,733,1,0,0,0,726,
+		728,5,87,0,0,727,729,5,45,0,0,728,727,1,0,0,0,728,729,1,0,0,0,729,730,
+		1,0,0,0,730,731,3,98,49,0,731,732,5,90,0,0,732,734,1,0,0,0,733,726,1,0,
+		0,0,733,734,1,0,0,0,734,735,1,0,0,0,735,736,5,85,0,0,736,737,3,90,45,0,
+		737,738,5,86,0,0,738,741,3,34,17,0,739,740,5,9,0,0,740,742,3,112,56,0,
+		741,739,1,0,0,0,741,742,1,0,0,0,742,743,1,0,0,0,743,744,3,122,61,0,744,
+		745,3,82,41,0,745,746,3,124,62,0,746,69,1,0,0,0,747,749,3,66,33,0,748,
+		747,1,0,0,0,748,749,1,0,0,0,749,754,1,0,0,0,750,755,5,70,0,0,751,752,5,
+		93,0,0,752,755,3,254,127,0,753,755,5,57,0,0,754,750,1,0,0,0,754,751,1,
+		0,0,0,754,753,1,0,0,0,755,764,1,0,0,0,756,757,5,85,0,0,757,758,3,90,45,
+		0,758,759,5,86,0,0,759,765,1,0,0,0,760,761,5,87,0,0,761,762,3,90,45,0,
+		762,763,5,90,0,0,763,765,1,0,0,0,764,756,1,0,0,0,764,760,1,0,0,0,764,765,
+		1,0,0,0,765,768,1,0,0,0,766,767,5,9,0,0,767,769,3,112,56,0,768,766,1,0,
+		0,0,768,769,1,0,0,0,769,770,1,0,0,0,770,772,3,120,60,0,771,773,3,78,39,
+		0,772,771,1,0,0,0,773,774,1,0,0,0,774,772,1,0,0,0,774,775,1,0,0,0,775,
+		776,1,0,0,0,776,777,3,124,62,0,777,796,1,0,0,0,778,796,3,72,36,0,779,783,
+		5,70,0,0,780,781,5,93,0,0,781,783,3,254,127,0,782,779,1,0,0,0,782,780,
+		1,0,0,0,783,786,1,0,0,0,784,785,5,9,0,0,785,787,3,112,56,0,786,784,1,0,
+		0,0,786,787,1,0,0,0,787,791,1,0,0,0,788,789,5,102,0,0,789,792,3,74,37,
+		0,790,792,3,8,4,0,791,788,1,0,0,0,791,790,1,0,0,0,792,793,1,0,0,0,793,
+		794,3,6,3,0,794,796,1,0,0,0,795,748,1,0,0,0,795,778,1,0,0,0,795,782,1,
+		0,0,0,796,71,1,0,0,0,797,798,3,140,70,0,798,73,1,0,0,0,799,800,3,284,142,
+		0,800,801,3,216,108,0,801,807,1,0,0,0,802,803,3,206,103,0,803,804,3,8,
+		4,0,804,807,1,0,0,0,805,807,3,168,84,0,806,799,1,0,0,0,806,802,1,0,0,0,
+		806,805,1,0,0,0,807,75,1,0,0,0,808,811,3,206,103,0,809,811,3,168,84,0,
+		810,808,1,0,0,0,810,809,1,0,0,0,811,77,1,0,0,0,812,813,3,34,17,0,813,814,
+		3,84,42,0,814,817,7,5,0,0,815,818,3,8,4,0,816,818,3,126,63,0,817,815,1,
+		0,0,0,817,816,1,0,0,0,818,79,1,0,0,0,819,821,3,8,4,0,820,819,1,0,0,0,820,
+		821,1,0,0,0,821,825,1,0,0,0,822,824,3,152,76,0,823,822,1,0,0,0,824,827,
+		1,0,0,0,825,823,1,0,0,0,825,826,1,0,0,0,826,81,1,0,0,0,827,825,1,0,0,0,
+		828,830,3,8,4,0,829,828,1,0,0,0,829,830,1,0,0,0,830,832,1,0,0,0,831,833,
+		3,152,76,0,832,831,1,0,0,0,833,834,1,0,0,0,834,832,1,0,0,0,834,835,1,0,
+		0,0,835,83,1,0,0,0,836,838,3,86,43,0,837,836,1,0,0,0,838,841,1,0,0,0,839,
+		837,1,0,0,0,839,840,1,0,0,0,840,85,1,0,0,0,841,839,1,0,0,0,842,843,7,6,
+		0,0,843,87,1,0,0,0,844,845,5,54,0,0,845,89,1,0,0,0,846,851,3,92,46,0,847,
+		848,5,113,0,0,848,850,3,92,46,0,849,847,1,0,0,0,850,853,1,0,0,0,851,849,
+		1,0,0,0,851,852,1,0,0,0,852,855,1,0,0,0,853,851,1,0,0,0,854,846,1,0,0,
+		0,854,855,1,0,0,0,855,91,1,0,0,0,856,879,3,34,17,0,857,861,5,101,0,0,858,
+		862,5,70,0,0,859,860,5,93,0,0,860,862,3,254,127,0,861,858,1,0,0,0,861,
+		859,1,0,0,0,862,865,1,0,0,0,863,864,5,9,0,0,864,866,3,106,53,0,865,863,
+		1,0,0,0,865,866,1,0,0,0,866,880,1,0,0,0,867,869,3,88,44,0,868,867,1,0,
+		0,0,868,869,1,0,0,0,869,873,1,0,0,0,870,874,5,70,0,0,871,872,5,93,0,0,
+		872,874,3,254,127,0,873,870,1,0,0,0,873,871,1,0,0,0,874,877,1,0,0,0,875,
+		876,5,9,0,0,876,878,3,112,56,0,877,875,1,0,0,0,877,878,1,0,0,0,878,880,
+		1,0,0,0,879,857,1,0,0,0,879,868,1,0,0,0,880,93,1,0,0,0,881,886,3,96,48,
+		0,882,883,5,113,0,0,883,885,3,96,48,0,884,882,1,0,0,0,885,888,1,0,0,0,
+		886,884,1,0,0,0,886,887,1,0,0,0,887,890,1,0,0,0,888,886,1,0,0,0,889,881,
+		1,0,0,0,889,890,1,0,0,0,890,95,1,0,0,0,891,892,5,101,0,0,892,898,3,112,
+		56,0,893,895,3,88,44,0,894,893,1,0,0,0,894,895,1,0,0,0,895,896,1,0,0,0,
+		896,898,3,112,56,0,897,891,1,0,0,0,897,894,1,0,0,0,898,97,1,0,0,0,899,
+		904,3,100,50,0,900,901,5,113,0,0,901,903,3,100,50,0,902,900,1,0,0,0,903,
+		906,1,0,0,0,904,902,1,0,0,0,904,905,1,0,0,0,905,99,1,0,0,0,906,904,1,0,
+		0,0,907,912,5,70,0,0,908,909,5,85,0,0,909,910,3,102,51,0,910,911,5,86,
+		0,0,911,913,1,0,0,0,912,908,1,0,0,0,912,913,1,0,0,0,913,101,1,0,0,0,914,
+		919,5,15,0,0,915,919,5,60,0,0,916,919,5,16,0,0,917,919,3,112,56,0,918,
+		914,1,0,0,0,918,915,1,0,0,0,918,916,1,0,0,0,918,917,1,0,0,0,919,922,1,
+		0,0,0,920,921,5,113,0,0,921,923,3,102,51,0,922,920,1,0,0,0,922,923,1,0,
+		0,0,923,103,1,0,0,0,924,925,5,12,0,0,925,926,5,85,0,0,926,927,3,94,47,
+		0,927,930,5,86,0,0,928,929,5,9,0,0,929,931,3,112,56,0,930,928,1,0,0,0,
+		930,931,1,0,0,0,931,105,1,0,0,0,932,933,5,85,0,0,933,936,3,112,56,0,934,
+		935,5,113,0,0,935,937,3,298,149,0,936,934,1,0,0,0,936,937,1,0,0,0,937,
+		938,1,0,0,0,938,939,5,86,0,0,939,107,1,0,0,0,940,945,3,112,56,0,941,942,
+		5,113,0,0,942,944,3,112,56,0,943,941,1,0,0,0,944,947,1,0,0,0,945,943,1,
+		0,0,0,945,946,1,0,0,0,946,109,1,0,0,0,947,945,1,0,0,0,948,949,5,93,0,0,
+		949,950,3,254,127,0,950,111,1,0,0,0,951,984,3,110,55,0,952,984,3,106,53,
+		0,953,984,3,104,52,0,954,978,3,116,58,0,955,957,5,87,0,0,956,958,5,45,
+		0,0,957,956,1,0,0,0,957,958,1,0,0,0,958,971,1,0,0,0,959,964,5,101,0,0,
+		960,961,5,113,0,0,961,963,5,101,0,0,962,960,1,0,0,0,963,966,1,0,0,0,964,
+		962,1,0,0,0,964,965,1,0,0,0,965,967,1,0,0,0,966,964,1,0,0,0,967,972,5,
+		90,0,0,968,969,3,108,54,0,969,970,5,90,0,0,970,972,1,0,0,0,971,959,1,0,
+		0,0,971,968,1,0,0,0,972,979,1,0,0,0,973,974,5,45,0,0,974,979,5,101,0,0,
+		975,976,5,45,0,0,976,979,3,112,56,0,977,979,1,0,0,0,978,955,1,0,0,0,978,
+		973,1,0,0,0,978,975,1,0,0,0,978,977,1,0,0,0,979,981,1,0,0,0,980,982,5,
+		124,0,0,981,980,1,0,0,0,981,982,1,0,0,0,982,984,1,0,0,0,983,951,1,0,0,
+		0,983,952,1,0,0,0,983,953,1,0,0,0,983,954,1,0,0,0,984,985,1,0,0,0,985,
+		986,3,114,57,0,986,113,1,0,0,0,987,989,7,7,0,0,988,987,1,0,0,0,989,992,
+		1,0,0,0,990,988,1,0,0,0,990,991,1,0,0,0,991,115,1,0,0,0,992,990,1,0,0,
+		0,993,997,3,330,165,0,994,997,5,12,0,0,995,997,5,14,0,0,996,993,1,0,0,
+		0,996,994,1,0,0,0,996,995,1,0,0,0,997,117,1,0,0,0,998,999,5,78,0,0,999,
+		1000,5,1,0,0,1000,119,1,0,0,0,1001,1005,5,78,0,0,1002,1003,3,8,4,0,1003,
+		1004,3,6,3,0,1004,1006,1,0,0,0,1005,1002,1,0,0,0,1005,1006,1,0,0,0,1006,
+		1007,1,0,0,0,1007,1008,5,1,0,0,1008,1009,3,6,3,0,1009,121,1,0,0,0,1010,
+		1014,5,78,0,0,1011,1012,3,8,4,0,1012,1013,3,6,3,0,1013,1015,1,0,0,0,1014,
+		1011,1,0,0,0,1014,1015,1,0,0,0,1015,1016,1,0,0,0,1016,1017,5,1,0,0,1017,
+		1018,3,6,3,0,1018,123,1,0,0,0,1019,1021,5,2,0,0,1020,1022,3,8,4,0,1021,
+		1020,1,0,0,0,1021,1022,1,0,0,0,1022,125,1,0,0,0,1023,1030,3,128,64,0,1024,
+		1025,5,78,0,0,1025,1026,5,1,0,0,1026,1027,3,82,41,0,1027,1028,3,124,62,
+		0,1028,1030,1,0,0,0,1029,1023,1,0,0,0,1029,1024,1,0,0,0,1030,127,1,0,0,
+		0,1031,1032,5,78,0,0,1032,1039,3,156,78,0,1033,1035,5,121,0,0,1034,1036,
+		3,156,78,0,1035,1034,1,0,0,0,1035,1036,1,0,0,0,1036,1038,1,0,0,0,1037,
+		1033,1,0,0,0,1038,1041,1,0,0,0,1039,1037,1,0,0,0,1039,1040,1,0,0,0,1040,
+		1043,1,0,0,0,1041,1039,1,0,0,0,1042,1044,5,6,0,0,1043,1042,1,0,0,0,1044,
+		1045,1,0,0,0,1045,1043,1,0,0,0,1045,1046,1,0,0,0,1046,129,1,0,0,0,1047,
+		1048,3,142,71,0,1048,1049,3,324,162,0,1049,131,1,0,0,0,1050,1053,3,152,
+		76,0,1051,1053,3,136,68,0,1052,1050,1,0,0,0,1052,1051,1,0,0,0,1053,133,
+		1,0,0,0,1054,1056,3,8,4,0,1055,1054,1,0,0,0,1055,1056,1,0,0,0,1056,1058,
+		1,0,0,0,1057,1059,3,132,66,0,1058,1057,1,0,0,0,1059,1060,1,0,0,0,1060,
+		1058,1,0,0,0,1060,1061,1,0,0,0,1061,135,1,0,0,0,1062,1063,3,48,24,0,1063,
+		137,1,0,0,0,1064,1071,3,128,64,0,1065,1066,5,78,0,0,1066,1067,5,1,0,0,
+		1067,1068,3,134,67,0,1068,1069,3,124,62,0,1069,1071,1,0,0,0,1070,1064,
+		1,0,0,0,1070,1065,1,0,0,0,1071,139,1,0,0,0,1072,1073,3,142,71,0,1073,1087,
+		3,324,162,0,1074,1075,3,120,60,0,1075,1076,3,134,67,0,1076,1077,3,124,
+		62,0,1077,1088,1,0,0,0,1078,1088,3,138,69,0,1079,1084,3,8,4,0,1080,1081,
+		3,158,79,0,1081,1082,3,8,4,0,1082,1084,1,0,0,0,1083,1079,1,0,0,0,1083,
+		1080,1,0,0,0,1084,1085,1,0,0,0,1085,1086,3,6,3,0,1086,1088,1,0,0,0,1087,
+		1074,1,0,0,0,1087,1078,1,0,0,0,1087,1083,1,0,0,0,1088,141,1,0,0,0,1089,
+		1090,7,8,0,0,1090,143,1,0,0,0,1091,1092,5,48,0,0,1092,145,1,0,0,0,1093,
+		1094,5,33,0,0,1094,1095,5,70,0,0,1095,147,1,0,0,0,1096,1097,5,78,0,0,1097,
+		1098,5,70,0,0,1098,149,1,0,0,0,1099,1100,5,17,0,0,1100,1108,5,70,0,0,1101,
+		1102,5,85,0,0,1102,1103,3,90,45,0,1103,1106,5,86,0,0,1104,1105,5,9,0,0,
+		1105,1107,3,112,56,0,1106,1104,1,0,0,0,1106,1107,1,0,0,0,1107,1109,1,0,
+		0,0,1108,1101,1,0,0,0,1108,1109,1,0,0,0,1109,1110,1,0,0,0,1110,1111,3,
+		126,63,0,1111,151,1,0,0,0,1112,1115,3,150,75,0,1113,1115,3,154,77,0,1114,
+		1112,1,0,0,0,1114,1113,1,0,0,0,1115,153,1,0,0,0,1116,1145,3,192,96,0,1117,
+		1145,3,194,97,0,1118,1145,3,196,98,0,1119,1145,3,190,95,0,1120,1145,3,
+		170,85,0,1121,1122,4,77,1,0,1122,1145,3,140,70,0,1123,1145,3,226,113,0,
+		1124,1145,3,182,91,0,1125,1145,3,198,99,0,1126,1145,3,176,88,0,1127,1128,
+		3,144,72,0,1128,1129,3,8,4,0,1129,1145,1,0,0,0,1130,1138,3,146,73,0,1131,
+		1138,3,148,74,0,1132,1138,3,184,92,0,1133,1138,3,186,93,0,1134,1138,3,
+		188,94,0,1135,1138,3,174,87,0,1136,1138,3,178,89,0,1137,1130,1,0,0,0,1137,
+		1131,1,0,0,0,1137,1132,1,0,0,0,1137,1133,1,0,0,0,1137,1134,1,0,0,0,1137,
+		1135,1,0,0,0,1137,1136,1,0,0,0,1138,1140,1,0,0,0,1139,1141,3,158,79,0,
+		1140,1139,1,0,0,0,1140,1141,1,0,0,0,1141,1142,1,0,0,0,1142,1143,3,8,4,
+		0,1143,1145,1,0,0,0,1144,1116,1,0,0,0,1144,1117,1,0,0,0,1144,1118,1,0,
+		0,0,1144,1119,1,0,0,0,1144,1120,1,0,0,0,1144,1121,1,0,0,0,1144,1123,1,
+		0,0,0,1144,1124,1,0,0,0,1144,1125,1,0,0,0,1144,1126,1,0,0,0,1144,1127,
+		1,0,0,0,1144,1137,1,0,0,0,1145,155,1,0,0,0,1146,1147,4,78,2,0,1147,1163,
+		3,130,65,0,1148,1163,3,228,114,0,1149,1163,3,180,90,0,1150,1163,3,200,
+		100,0,1151,1163,3,176,88,0,1152,1163,3,144,72,0,1153,1161,3,146,73,0,1154,
+		1161,3,148,74,0,1155,1161,3,184,92,0,1156,1161,3,186,93,0,1157,1161,3,
+		188,94,0,1158,1161,3,174,87,0,1159,1161,3,178,89,0,1160,1153,1,0,0,0,1160,
+		1154,1,0,0,0,1160,1155,1,0,0,0,1160,1156,1,0,0,0,1160,1157,1,0,0,0,1160,
+		1158,1,0,0,0,1160,1159,1,0,0,0,1161,1163,1,0,0,0,1162,1146,1,0,0,0,1162,
+		1148,1,0,0,0,1162,1149,1,0,0,0,1162,1150,1,0,0,0,1162,1151,1,0,0,0,1162,
+		1152,1,0,0,0,1162,1160,1,0,0,0,1163,157,1,0,0,0,1164,1165,7,9,0,0,1165,
+		1166,3,212,106,0,1166,159,1,0,0,0,1167,1170,3,168,84,0,1168,1170,3,206,
+		103,0,1169,1167,1,0,0,0,1169,1168,1,0,0,0,1170,161,1,0,0,0,1171,1184,3,
+		180,90,0,1172,1179,3,200,100,0,1173,1174,4,81,3,0,1174,1179,3,130,65,0,
+		1175,1179,3,164,82,0,1176,1179,3,174,87,0,1177,1179,3,184,92,0,1178,1172,
+		1,0,0,0,1178,1173,1,0,0,0,1178,1175,1,0,0,0,1178,1176,1,0,0,0,1178,1177,
+		1,0,0,0,1179,1181,1,0,0,0,1180,1182,3,158,79,0,1181,1180,1,0,0,0,1181,
+		1182,1,0,0,0,1182,1184,1,0,0,0,1183,1171,1,0,0,0,1183,1178,1,0,0,0,1184,
+		163,1,0,0,0,1185,1186,3,206,103,0,1186,165,1,0,0,0,1187,1191,5,91,0,0,
+		1188,1189,3,90,45,0,1189,1190,5,79,0,0,1190,1192,1,0,0,0,1191,1188,1,0,
+		0,0,1191,1192,1,0,0,0,1192,1193,1,0,0,0,1193,1200,3,162,81,0,1194,1196,
+		3,8,4,0,1195,1197,3,162,81,0,1196,1195,1,0,0,0,1196,1197,1,0,0,0,1197,
+		1199,1,0,0,0,1198,1194,1,0,0,0,1199,1202,1,0,0,0,1200,1198,1,0,0,0,1200,
+		1201,1,0,0,0,1201,1203,1,0,0,0,1202,1200,1,0,0,0,1203,1204,5,92,0,0,1204,
+		167,1,0,0,0,1205,1218,3,126,63,0,1206,1214,7,10,0,0,1207,1208,5,85,0,0,
+		1208,1209,3,90,45,0,1209,1212,5,86,0,0,1210,1211,5,9,0,0,1211,1213,3,112,
+		56,0,1212,1210,1,0,0,0,1212,1213,1,0,0,0,1213,1215,1,0,0,0,1214,1207,1,
+		0,0,0,1214,1215,1,0,0,0,1215,1216,1,0,0,0,1216,1218,3,126,63,0,1217,1205,
+		1,0,0,0,1217,1206,1,0,0,0,1218,169,1,0,0,0,1219,1220,5,62,0,0,1220,1224,
+		3,126,63,0,1221,1223,3,172,86,0,1222,1221,1,0,0,0,1223,1226,1,0,0,0,1224,
+		1222,1,0,0,0,1224,1225,1,0,0,0,1225,1229,1,0,0,0,1226,1224,1,0,0,0,1227,
+		1228,5,27,0,0,1228,1230,3,126,63,0,1229,1227,1,0,0,0,1229,1230,1,0,0,0,
+		1230,1233,1,0,0,0,1231,1232,5,23,0,0,1232,1234,3,126,63,0,1233,1231,1,
+		0,0,0,1233,1234,1,0,0,0,1234,171,1,0,0,0,1235,1237,5,26,0,0,1236,1238,
+		5,70,0,0,1237,1236,1,0,0,0,1237,1238,1,0,0,0,1238,1241,1,0,0,0,1239,1240,
+		5,9,0,0,1240,1242,3,112,56,0,1241,1239,1,0,0,0,1241,1242,1,0,0,0,1242,
+		1245,1,0,0,0,1243,1244,7,11,0,0,1244,1246,3,212,106,0,1245,1243,1,0,0,
+		0,1245,1246,1,0,0,0,1246,1247,1,0,0,0,1247,1248,3,126,63,0,1248,173,1,
+		0,0,0,1249,1251,5,53,0,0,1250,1252,3,208,104,0,1251,1250,1,0,0,0,1251,
+		1252,1,0,0,0,1252,175,1,0,0,0,1253,1254,5,70,0,0,1254,1255,5,9,0,0,1255,
+		1265,3,112,56,0,1256,1259,5,102,0,0,1257,1260,3,74,37,0,1258,1260,3,76,
+		38,0,1259,1257,1,0,0,0,1259,1258,1,0,0,0,1260,1266,1,0,0,0,1261,1263,3,
+		158,79,0,1262,1261,1,0,0,0,1262,1263,1,0,0,0,1263,1264,1,0,0,0,1264,1266,
+		3,8,4,0,1265,1256,1,0,0,0,1265,1262,1,0,0,0,1266,177,1,0,0,0,1267,1268,
+		3,232,116,0,1268,179,1,0,0,0,1269,1271,5,55,0,0,1270,1272,3,206,103,0,
+		1271,1270,1,0,0,0,1271,1272,1,0,0,0,1272,1274,1,0,0,0,1273,1275,3,158,
+		79,0,1274,1273,1,0,0,0,1274,1275,1,0,0,0,1275,181,1,0,0,0,1276,1290,5,
+		55,0,0,1277,1283,3,206,103,0,1278,1284,3,216,108,0,1279,1281,3,158,79,
+		0,1280,1279,1,0,0,0,1280,1281,1,0,0,0,1281,1282,1,0,0,0,1282,1284,3,8,
+		4,0,1283,1278,1,0,0,0,1283,1280,1,0,0,0,1284,1291,1,0,0,0,1285,1291,3,
+		168,84,0,1286,1288,3,158,79,0,1287,1286,1,0,0,0,1287,1288,1,0,0,0,1288,
+		1289,1,0,0,0,1289,1291,3,8,4,0,1290,1277,1,0,0,0,1290,1285,1,0,0,0,1290,
+		1287,1,0,0,0,1291,183,1,0,0,0,1292,1294,5,69,0,0,1293,1295,3,206,103,0,
+		1294,1293,1,0,0,0,1294,1295,1,0,0,0,1295,185,1,0,0,0,1296,1297,5,10,0,
+		0,1297,187,1,0,0,0,1298,1299,5,11,0,0,1299,189,1,0,0,0,1300,1301,5,66,
+		0,0,1301,1302,3,208,104,0,1302,1303,3,126,63,0,1303,191,1,0,0,0,1304,1305,
+		5,30,0,0,1305,1306,3,202,101,0,1306,1307,5,40,0,0,1307,1308,3,206,103,
+		0,1308,1311,3,126,63,0,1309,1310,5,46,0,0,1310,1312,3,126,63,0,1311,1309,
+		1,0,0,0,1311,1312,1,0,0,0,1312,1315,1,0,0,0,1313,1314,5,61,0,0,1314,1316,
+		3,126,63,0,1315,1313,1,0,0,0,1315,1316,1,0,0,0,1316,193,1,0,0,0,1317,1318,
+		5,68,0,0,1318,1319,3,208,104,0,1319,1322,3,126,63,0,1320,1321,5,46,0,0,
+		1321,1323,3,126,63,0,1322,1320,1,0,0,0,1322,1323,1,0,0,0,1323,1326,1,0,
+		0,0,1324,1325,5,61,0,0,1325,1327,3,126,63,0,1326,1324,1,0,0,0,1326,1327,
+		1,0,0,0,1327,195,1,0,0,0,1328,1329,5,39,0,0,1329,1330,3,208,104,0,1330,
+		1337,3,126,63,0,1331,1332,5,20,0,0,1332,1333,3,208,104,0,1333,1334,3,126,
+		63,0,1334,1336,1,0,0,0,1335,1331,1,0,0,0,1336,1339,1,0,0,0,1337,1335,1,
+		0,0,0,1337,1338,1,0,0,0,1338,1342,1,0,0,0,1339,1337,1,0,0,0,1340,1341,
+		5,21,0,0,1341,1343,3,126,63,0,1342,1340,1,0,0,0,1342,1343,1,0,0,0,1343,
+		197,1,0,0,0,1344,1346,3,200,100,0,1345,1347,3,158,79,0,1346,1345,1,0,0,
+		0,1346,1347,1,0,0,0,1347,1348,1,0,0,0,1348,1349,3,8,4,0,1349,199,1,0,0,
+		0,1350,1351,3,204,102,0,1351,1353,5,113,0,0,1352,1354,3,202,101,0,1353,
+		1352,1,0,0,0,1353,1354,1,0,0,0,1354,1355,1,0,0,0,1355,1356,5,102,0,0,1356,
+		1357,3,206,103,0,1357,201,1,0,0,0,1358,1363,3,204,102,0,1359,1360,5,113,
+		0,0,1360,1362,3,204,102,0,1361,1359,1,0,0,0,1362,1365,1,0,0,0,1363,1361,
+		1,0,0,0,1363,1364,1,0,0,0,1364,203,1,0,0,0,1365,1363,1,0,0,0,1366,1369,
+		5,70,0,0,1367,1368,5,9,0,0,1368,1370,3,112,56,0,1369,1367,1,0,0,0,1369,
+		1370,1,0,0,0,1370,205,1,0,0,0,1371,1384,5,113,0,0,1372,1377,3,208,104,
+		0,1373,1374,5,113,0,0,1374,1376,3,208,104,0,1375,1373,1,0,0,0,1376,1379,
+		1,0,0,0,1377,1375,1,0,0,0,1377,1378,1,0,0,0,1378,1381,1,0,0,0,1379,1377,
+		1,0,0,0,1380,1382,5,113,0,0,1381,1380,1,0,0,0,1381,1382,1,0,0,0,1382,1384,
+		1,0,0,0,1383,1371,1,0,0,0,1383,1372,1,0,0,0,1384,207,1,0,0,0,1385,1390,
+		3,212,106,0,1386,1387,5,30,0,0,1387,1389,3,210,105,0,1388,1386,1,0,0,0,
+		1389,1392,1,0,0,0,1390,1388,1,0,0,0,1390,1391,1,0,0,0,1391,209,1,0,0,0,
+		1392,1390,1,0,0,0,1393,1394,3,202,101,0,1394,1395,5,40,0,0,1395,1397,3,
+		212,106,0,1396,1398,3,158,79,0,1397,1396,1,0,0,0,1397,1398,1,0,0,0,1398,
+		211,1,0,0,0,1399,1404,3,214,107,0,1400,1401,5,46,0,0,1401,1403,3,214,107,
+		0,1402,1400,1,0,0,0,1403,1406,1,0,0,0,1404,1402,1,0,0,0,1404,1405,1,0,
+		0,0,1405,213,1,0,0,0,1406,1404,1,0,0,0,1407,1412,3,230,115,0,1408,1409,
+		5,8,0,0,1409,1411,3,230,115,0,1410,1408,1,0,0,0,1411,1414,1,0,0,0,1412,
+		1410,1,0,0,0,1412,1413,1,0,0,0,1413,215,1,0,0,0,1414,1412,1,0,0,0,1415,
+		1416,3,168,84,0,1416,217,1,0,0,0,1417,1425,5,94,0,0,1418,1419,5,1,0,0,
+		1419,1420,3,222,111,0,1420,1422,5,2,0,0,1421,1423,3,8,4,0,1422,1421,1,
+		0,0,0,1422,1423,1,0,0,0,1423,1426,1,0,0,0,1424,1426,3,224,112,0,1425,1418,
+		1,0,0,0,1425,1424,1,0,0,0,1426,1427,1,0,0,0,1427,1428,5,95,0,0,1428,219,
+		1,0,0,0,1429,1430,3,2,1,0,1430,221,1,0,0,0,1431,1433,3,154,77,0,1432,1431,
+		1,0,0,0,1433,1434,1,0,0,0,1434,1432,1,0,0,0,1434,1435,1,0,0,0,1435,1443,
+		1,0,0,0,1436,1438,3,48,24,0,1437,1436,1,0,0,0,1438,1439,1,0,0,0,1439,1437,
+		1,0,0,0,1439,1440,1,0,0,0,1440,1443,1,0,0,0,1441,1443,3,220,110,0,1442,
+		1432,1,0,0,0,1442,1437,1,0,0,0,1442,1441,1,0,0,0,1443,223,1,0,0,0,1444,
+		1447,3,208,104,0,1445,1446,5,78,0,0,1446,1448,3,208,104,0,1447,1445,1,
+		0,0,0,1447,1448,1,0,0,0,1448,1461,1,0,0,0,1449,1461,3,16,8,0,1450,1457,
+		3,162,81,0,1451,1453,3,8,4,0,1452,1454,3,162,81,0,1453,1452,1,0,0,0,1453,
+		1454,1,0,0,0,1454,1456,1,0,0,0,1455,1451,1,0,0,0,1456,1459,1,0,0,0,1457,
+		1455,1,0,0,0,1457,1458,1,0,0,0,1458,1461,1,0,0,0,1459,1457,1,0,0,0,1460,
+		1444,1,0,0,0,1460,1449,1,0,0,0,1460,1450,1,0,0,0,1461,225,1,0,0,0,1462,
+		1476,3,284,142,0,1463,1477,3,216,108,0,1464,1474,5,102,0,0,1465,1471,3,
+		206,103,0,1466,1472,3,216,108,0,1467,1468,3,158,79,0,1468,1469,3,8,4,0,
+		1469,1472,1,0,0,0,1470,1472,3,8,4,0,1471,1466,1,0,0,0,1471,1467,1,0,0,
+		0,1471,1470,1,0,0,0,1472,1475,1,0,0,0,1473,1475,3,168,84,0,1474,1465,1,
+		0,0,0,1474,1473,1,0,0,0,1475,1477,1,0,0,0,1476,1463,1,0,0,0,1476,1464,
+		1,0,0,0,1477,227,1,0,0,0,1478,1479,3,284,142,0,1479,1480,5,102,0,0,1480,
+		1481,3,206,103,0,1481,229,1,0,0,0,1482,1483,5,43,0,0,1483,1486,3,230,115,
+		0,1484,1486,3,232,116,0,1485,1482,1,0,0,0,1485,1484,1,0,0,0,1486,231,1,
+		0,0,0,1487,1490,3,236,118,0,1488,1489,7,12,0,0,1489,1491,3,232,116,0,1490,
+		1488,1,0,0,0,1490,1491,1,0,0,0,1491,233,1,0,0,0,1492,1502,5,112,0,0,1493,
+		1502,5,108,0,0,1494,1502,5,105,0,0,1495,1496,5,37,0,0,1496,1502,5,43,0,
+		0,1497,1502,5,37,0,0,1498,1499,5,43,0,0,1499,1502,5,40,0,0,1500,1502,5,
+		40,0,0,1501,1492,1,0,0,0,1501,1493,1,0,0,0,1501,1494,1,0,0,0,1501,1495,
+		1,0,0,0,1501,1497,1,0,0,0,1501,1498,1,0,0,0,1501,1500,1,0,0,0,1502,1503,
+		1,0,0,0,1503,1507,3,240,120,0,1504,1505,5,38,0,0,1505,1507,3,112,56,0,
+		1506,1501,1,0,0,0,1506,1504,1,0,0,0,1507,235,1,0,0,0,1508,1512,3,240,120,
+		0,1509,1511,3,234,117,0,1510,1509,1,0,0,0,1511,1514,1,0,0,0,1512,1510,
+		1,0,0,0,1512,1513,1,0,0,0,1513,237,1,0,0,0,1514,1512,1,0,0,0,1515,1516,
+		7,13,0,0,1516,1517,3,244,122,0,1517,239,1,0,0,0,1518,1522,3,244,122,0,
+		1519,1521,3,238,119,0,1520,1519,1,0,0,0,1521,1524,1,0,0,0,1522,1520,1,
+		0,0,0,1522,1523,1,0,0,0,1523,241,1,0,0,0,1524,1522,1,0,0,0,1525,1526,7,
+		14,0,0,1526,1527,3,248,124,0,1527,243,1,0,0,0,1528,1532,3,248,124,0,1529,
+		1531,3,242,121,0,1530,1529,1,0,0,0,1531,1534,1,0,0,0,1532,1530,1,0,0,0,
+		1532,1533,1,0,0,0,1533,245,1,0,0,0,1534,1532,1,0,0,0,1535,1536,7,15,0,
+		0,1536,1537,3,250,125,0,1537,247,1,0,0,0,1538,1542,3,250,125,0,1539,1541,
+		3,246,123,0,1540,1539,1,0,0,0,1541,1544,1,0,0,0,1542,1540,1,0,0,0,1542,
+		1543,1,0,0,0,1543,249,1,0,0,0,1544,1542,1,0,0,0,1545,1550,3,252,126,0,
+		1546,1547,5,9,0,0,1547,1551,3,112,56,0,1548,1549,5,13,0,0,1549,1551,3,
+		112,56,0,1550,1546,1,0,0,0,1550,1548,1,0,0,0,1550,1551,1,0,0,0,1551,1556,
+		1,0,0,0,1552,1553,5,103,0,0,1553,1555,3,250,125,0,1554,1552,1,0,0,0,1555,
+		1558,1,0,0,0,1556,1554,1,0,0,0,1556,1557,1,0,0,0,1557,251,1,0,0,0,1558,
+		1556,1,0,0,0,1559,1560,4,126,4,0,1560,1568,3,298,149,0,1561,1562,7,16,
+		0,0,1562,1568,3,252,126,0,1563,1565,3,284,142,0,1564,1566,7,17,0,0,1565,
+		1564,1,0,0,0,1565,1566,1,0,0,0,1566,1568,1,0,0,0,1567,1559,1,0,0,0,1567,
+		1561,1,0,0,0,1567,1563,1,0,0,0,1568,253,1,0,0,0,1569,1578,3,288,144,0,
+		1570,1578,3,260,130,0,1571,1578,3,266,133,0,1572,1578,3,268,134,0,1573,
+		1578,3,262,131,0,1574,1578,3,264,132,0,1575,1578,3,258,129,0,1576,1578,
+		3,256,128,0,1577,1569,1,0,0,0,1577,1570,1,0,0,0,1577,1571,1,0,0,0,1577,
+		1572,1,0,0,0,1577,1573,1,0,0,0,1577,1574,1,0,0,0,1577,1575,1,0,0,0,1577,
+		1576,1,0,0,0,1578,255,1,0,0,0,1579,1580,5,77,0,0,1580,1581,3,272,136,0,
+		1581,257,1,0,0,0,1582,1583,5,93,0,0,1583,1584,3,254,127,0,1584,259,1,0,
+		0,0,1585,1586,5,14,0,0,1586,1588,5,85,0,0,1587,1589,7,18,0,0,1588,1587,
+		1,0,0,0,1588,1589,1,0,0,0,1589,1590,1,0,0,0,1590,1591,5,86,0,0,1591,261,
+		1,0,0,0,1592,1593,5,13,0,0,1593,1594,5,85,0,0,1594,1595,3,112,56,0,1595,
+		1596,5,113,0,0,1596,1597,3,208,104,0,1597,1598,5,86,0,0,1598,263,1,0,0,
+		0,1599,1600,5,65,0,0,1600,1601,5,85,0,0,1601,1602,3,112,56,0,1602,1603,
+		5,86,0,0,1603,265,1,0,0,0,1604,1607,3,142,71,0,1605,1607,5,14,0,0,1606,
+		1604,1,0,0,0,1606,1605,1,0,0,0,1607,267,1,0,0,0,1608,1621,3,270,135,0,
+		1609,1610,5,85,0,0,1610,1616,3,206,103,0,1611,1612,5,39,0,0,1612,1613,
+		3,212,106,0,1613,1614,5,21,0,0,1614,1615,3,206,103,0,1615,1617,1,0,0,0,
+		1616,1611,1,0,0,0,1616,1617,1,0,0,0,1617,1618,1,0,0,0,1618,1619,5,86,0,
+		0,1619,1621,1,0,0,0,1620,1608,1,0,0,0,1620,1609,1,0,0,0,1621,269,1,0,0,
+		0,1622,1623,5,85,0,0,1623,1624,5,45,0,0,1624,1625,3,112,56,0,1625,1638,
+		5,78,0,0,1626,1639,5,113,0,0,1627,1632,3,208,104,0,1628,1629,5,113,0,0,
+		1629,1631,3,208,104,0,1630,1628,1,0,0,0,1631,1634,1,0,0,0,1632,1630,1,
+		0,0,0,1632,1633,1,0,0,0,1633,1636,1,0,0,0,1634,1632,1,0,0,0,1635,1637,
+		5,113,0,0,1636,1635,1,0,0,0,1636,1637,1,0,0,0,1637,1639,1,0,0,0,1638,1626,
+		1,0,0,0,1638,1627,1,0,0,0,1639,1640,1,0,0,0,1640,1641,5,86,0,0,1641,271,
+		1,0,0,0,1642,1643,7,19,0,0,1643,273,1,0,0,0,1644,1649,5,78,0,0,1645,1650,
+		3,208,104,0,1646,1647,5,78,0,0,1647,1650,3,208,104,0,1648,1650,1,0,0,0,
+		1649,1645,1,0,0,0,1649,1646,1,0,0,0,1649,1648,1,0,0,0,1650,275,1,0,0,0,
+		1651,1660,3,208,104,0,1652,1654,5,78,0,0,1653,1655,3,208,104,0,1654,1653,
+		1,0,0,0,1654,1655,1,0,0,0,1655,1658,1,0,0,0,1656,1657,5,78,0,0,1657,1659,
+		3,208,104,0,1658,1656,1,0,0,0,1658,1659,1,0,0,0,1659,1661,1,0,0,0,1660,
+		1652,1,0,0,0,1660,1661,1,0,0,0,1661,277,1,0,0,0,1662,1665,3,274,137,0,
+		1663,1665,3,276,138,0,1664,1662,1,0,0,0,1664,1663,1,0,0,0,1665,279,1,0,
+		0,0,1666,1668,3,254,127,0,1667,1669,5,124,0,0,1668,1667,1,0,0,0,1668,1669,
+		1,0,0,0,1669,281,1,0,0,0,1670,1681,5,87,0,0,1671,1672,5,45,0,0,1672,1682,
+		3,108,54,0,1673,1678,3,278,139,0,1674,1675,5,113,0,0,1675,1677,3,278,139,
+		0,1676,1674,1,0,0,0,1677,1680,1,0,0,0,1678,1676,1,0,0,0,1678,1679,1,0,
+		0,0,1679,1682,1,0,0,0,1680,1678,1,0,0,0,1681,1671,1,0,0,0,1681,1673,1,
+		0,0,0,1682,1683,1,0,0,0,1683,1685,5,90,0,0,1684,1686,5,124,0,0,1685,1684,
+		1,0,0,0,1685,1686,1,0,0,0,1686,1718,1,0,0,0,1687,1688,5,45,0,0,1688,1718,
+		3,112,56,0,1689,1693,5,77,0,0,1690,1694,3,272,136,0,1691,1692,5,93,0,0,
+		1692,1694,3,254,127,0,1693,1690,1,0,0,0,1693,1691,1,0,0,0,1694,1696,1,
+		0,0,0,1695,1697,5,124,0,0,1696,1695,1,0,0,0,1696,1697,1,0,0,0,1697,1718,
+		1,0,0,0,1698,1707,5,85,0,0,1699,1704,3,328,164,0,1700,1701,5,113,0,0,1701,
+		1703,3,328,164,0,1702,1700,1,0,0,0,1703,1706,1,0,0,0,1704,1702,1,0,0,0,
+		1704,1705,1,0,0,0,1705,1708,1,0,0,0,1706,1704,1,0,0,0,1707,1699,1,0,0,
+		0,1707,1708,1,0,0,0,1708,1709,1,0,0,0,1709,1711,5,86,0,0,1710,1712,5,124,
+		0,0,1711,1710,1,0,0,0,1711,1712,1,0,0,0,1712,1715,1,0,0,0,1713,1716,3,
+		314,157,0,1714,1716,3,286,143,0,1715,1713,1,0,0,0,1715,1714,1,0,0,0,1715,
+		1716,1,0,0,0,1716,1718,1,0,0,0,1717,1670,1,0,0,0,1717,1687,1,0,0,0,1717,
+		1689,1,0,0,0,1717,1698,1,0,0,0,1718,283,1,0,0,0,1719,1723,3,280,140,0,
+		1720,1722,3,282,141,0,1721,1720,1,0,0,0,1722,1725,1,0,0,0,1723,1721,1,
+		0,0,0,1723,1724,1,0,0,0,1724,285,1,0,0,0,1725,1723,1,0,0,0,1726,1727,5,
+		91,0,0,1727,1728,3,312,156,0,1728,1729,5,92,0,0,1729,287,1,0,0,0,1730,
+		1744,3,298,149,0,1731,1744,3,300,150,0,1732,1744,3,310,155,0,1733,1744,
+		3,314,157,0,1734,1744,3,166,83,0,1735,1744,3,218,109,0,1736,1744,3,318,
+		159,0,1737,1744,3,296,148,0,1738,1744,3,294,147,0,1739,1744,3,290,145,
+		0,1740,1744,3,292,146,0,1741,1744,3,320,160,0,1742,1744,3,322,161,0,1743,
+		1730,1,0,0,0,1743,1731,1,0,0,0,1743,1732,1,0,0,0,1743,1733,1,0,0,0,1743,
+		1734,1,0,0,0,1743,1735,1,0,0,0,1743,1736,1,0,0,0,1743,1737,1,0,0,0,1743,
+		1738,1,0,0,0,1743,1739,1,0,0,0,1743,1740,1,0,0,0,1743,1741,1,0,0,0,1743,
+		1742,1,0,0,0,1744,289,1,0,0,0,1745,1746,5,57,0,0,1746,291,1,0,0,0,1747,
+		1748,5,58,0,0,1748,293,1,0,0,0,1749,1750,5,44,0,0,1750,295,1,0,0,0,1751,
+		1752,7,20,0,0,1752,297,1,0,0,0,1753,1755,5,99,0,0,1754,1753,1,0,0,0,1754,
+		1755,1,0,0,0,1755,1756,1,0,0,0,1756,1757,7,21,0,0,1757,299,1,0,0,0,1758,
+		1764,3,308,154,0,1759,1764,3,302,151,0,1760,1764,5,116,0,0,1761,1764,3,
+		304,152,0,1762,1764,5,117,0,0,1763,1758,1,0,0,0,1763,1759,1,0,0,0,1763,
+		1760,1,0,0,0,1763,1761,1,0,0,0,1763,1762,1,0,0,0,1764,301,1,0,0,0,1765,
+		1787,5,115,0,0,1766,1786,5,127,0,0,1767,1786,5,126,0,0,1768,1769,5,129,
+		0,0,1769,1772,3,208,104,0,1770,1771,5,78,0,0,1771,1773,5,70,0,0,1772,1770,
+		1,0,0,0,1772,1773,1,0,0,0,1773,1774,1,0,0,0,1774,1775,5,92,0,0,1775,1786,
+		1,0,0,0,1776,1777,5,130,0,0,1777,1780,3,208,104,0,1778,1779,5,78,0,0,1779,
+		1781,5,70,0,0,1780,1778,1,0,0,0,1780,1781,1,0,0,0,1781,1782,1,0,0,0,1782,
+		1783,5,86,0,0,1783,1786,1,0,0,0,1784,1786,5,128,0,0,1785,1766,1,0,0,0,
+		1785,1767,1,0,0,0,1785,1768,1,0,0,0,1785,1776,1,0,0,0,1785,1784,1,0,0,
+		0,1786,1789,1,0,0,0,1787,1785,1,0,0,0,1787,1788,1,0,0,0,1788,1790,1,0,
+		0,0,1789,1787,1,0,0,0,1790,1791,5,131,0,0,1791,303,1,0,0,0,1792,1813,5,
+		114,0,0,1793,1812,5,127,0,0,1794,1795,5,129,0,0,1795,1798,3,208,104,0,
+		1796,1797,5,78,0,0,1797,1799,5,70,0,0,1798,1796,1,0,0,0,1798,1799,1,0,
+		0,0,1799,1800,1,0,0,0,1800,1801,5,92,0,0,1801,1812,1,0,0,0,1802,1803,5,
+		130,0,0,1803,1806,3,208,104,0,1804,1805,5,78,0,0,1805,1807,5,70,0,0,1806,
+		1804,1,0,0,0,1806,1807,1,0,0,0,1807,1808,1,0,0,0,1808,1809,5,86,0,0,1809,
+		1812,1,0,0,0,1810,1812,5,128,0,0,1811,1793,1,0,0,0,1811,1794,1,0,0,0,1811,
+		1802,1,0,0,0,1811,1810,1,0,0,0,1812,1815,1,0,0,0,1813,1811,1,0,0,0,1813,
+		1814,1,0,0,0,1814,1816,1,0,0,0,1815,1813,1,0,0,0,1816,1817,5,125,0,0,1817,
+		305,1,0,0,0,1818,1819,5,5,0,0,1819,1824,3,208,104,0,1820,1822,5,78,0,0,
+		1821,1820,1,0,0,0,1821,1822,1,0,0,0,1822,1823,1,0,0,0,1823,1825,5,70,0,
+		0,1824,1821,1,0,0,0,1824,1825,1,0,0,0,1825,1826,1,0,0,0,1826,1827,5,5,
+		0,0,1827,307,1,0,0,0,1828,1830,5,5,0,0,1829,1828,1,0,0,0,1829,1830,1,0,
+		0,0,1830,1832,1,0,0,0,1831,1833,3,306,153,0,1832,1831,1,0,0,0,1833,1834,
+		1,0,0,0,1834,1832,1,0,0,0,1834,1835,1,0,0,0,1835,1837,1,0,0,0,1836,1838,
+		5,5,0,0,1837,1836,1,0,0,0,1837,1838,1,0,0,0,1838,309,1,0,0,0,1839,1840,
+		5,87,0,0,1840,1841,3,312,156,0,1841,1842,5,90,0,0,1842,311,1,0,0,0,1843,
+		1848,3,208,104,0,1844,1845,5,113,0,0,1845,1847,3,208,104,0,1846,1844,1,
+		0,0,0,1847,1850,1,0,0,0,1848,1846,1,0,0,0,1848,1849,1,0,0,0,1849,1852,
+		1,0,0,0,1850,1848,1,0,0,0,1851,1853,5,113,0,0,1852,1851,1,0,0,0,1852,1853,
+		1,0,0,0,1853,1855,1,0,0,0,1854,1843,1,0,0,0,1854,1855,1,0,0,0,1855,313,
+		1,0,0,0,1856,1868,5,91,0,0,1857,1862,3,316,158,0,1858,1859,5,113,0,0,1859,
+		1861,3,316,158,0,1860,1858,1,0,0,0,1861,1864,1,0,0,0,1862,1860,1,0,0,0,
+		1862,1863,1,0,0,0,1863,1866,1,0,0,0,1864,1862,1,0,0,0,1865,1867,5,113,
+		0,0,1866,1865,1,0,0,0,1866,1867,1,0,0,0,1867,1869,1,0,0,0,1868,1857,1,
+		0,0,0,1868,1869,1,0,0,0,1869,1870,1,0,0,0,1870,1871,5,92,0,0,1871,315,
+		1,0,0,0,1872,1873,3,208,104,0,1873,1874,5,78,0,0,1874,1875,3,208,104,0,
+		1875,317,1,0,0,0,1876,1877,5,123,0,0,1877,319,1,0,0,0,1878,1880,5,99,0,
+		0,1879,1878,1,0,0,0,1879,1880,1,0,0,0,1880,1881,1,0,0,0,1881,1884,5,75,
+		0,0,1882,1884,5,74,0,0,1883,1879,1,0,0,0,1883,1882,1,0,0,0,1884,321,1,
+		0,0,0,1885,1887,5,99,0,0,1886,1885,1,0,0,0,1886,1887,1,0,0,0,1887,1888,
+		1,0,0,0,1888,1889,5,76,0,0,1889,323,1,0,0,0,1890,1895,3,208,104,0,1891,
+		1892,5,113,0,0,1892,1894,3,208,104,0,1893,1891,1,0,0,0,1894,1897,1,0,0,
+		0,1895,1893,1,0,0,0,1895,1896,1,0,0,0,1896,1899,1,0,0,0,1897,1895,1,0,
+		0,0,1898,1890,1,0,0,0,1898,1899,1,0,0,0,1899,325,1,0,0,0,1900,1905,3,328,
+		164,0,1901,1902,5,113,0,0,1902,1904,3,328,164,0,1903,1901,1,0,0,0,1904,
+		1907,1,0,0,0,1905,1903,1,0,0,0,1905,1906,1,0,0,0,1906,1909,1,0,0,0,1907,
+		1905,1,0,0,0,1908,1900,1,0,0,0,1908,1909,1,0,0,0,1909,327,1,0,0,0,1910,
+		1913,3,316,158,0,1911,1913,3,208,104,0,1912,1910,1,0,0,0,1912,1911,1,0,
+		0,0,1913,329,1,0,0,0,1914,1919,3,142,71,0,1915,1916,5,77,0,0,1916,1918,
+		3,272,136,0,1917,1915,1,0,0,0,1918,1921,1,0,0,0,1919,1917,1,0,0,0,1919,
+		1920,1,0,0,0,1920,331,1,0,0,0,1921,1919,1,0,0,0,259,336,340,343,348,354,
+		356,362,368,375,377,382,386,397,405,407,411,418,429,432,438,444,449,456,
+		469,471,477,483,494,497,501,505,510,516,528,534,538,543,546,552,557,559,
+		573,579,585,589,594,597,605,607,617,620,628,632,639,646,653,655,662,666,
+		672,680,699,704,709,715,720,724,728,733,741,748,754,764,768,774,782,786,
+		791,795,806,810,817,820,825,829,834,839,851,854,861,865,868,873,877,879,
+		886,889,894,897,904,912,918,922,930,936,945,957,964,971,978,981,983,990,
+		996,1005,1014,1021,1029,1035,1039,1045,1052,1055,1060,1070,1083,1087,1106,
+		1108,1114,1137,1140,1144,1160,1162,1169,1178,1181,1183,1191,1196,1200,
+		1212,1214,1217,1224,1229,1233,1237,1241,1245,1251,1259,1262,1265,1271,
+		1274,1280,1283,1287,1290,1294,1311,1315,1322,1326,1337,1342,1346,1353,
+		1363,1369,1377,1381,1383,1390,1397,1404,1412,1422,1425,1434,1439,1442,
+		1447,1453,1457,1460,1471,1474,1476,1485,1490,1501,1506,1512,1522,1532,
+		1542,1550,1556,1565,1567,1577,1588,1606,1616,1620,1632,1636,1638,1649,
+		1654,1658,1660,1664,1668,1678,1681,1685,1693,1696,1704,1707,1711,1715,
+		1717,1723,1743,1754,1763,1772,1780,1785,1787,1798,1806,1811,1813,1821,
+		1824,1829,1834,1837,1848,1852,1854,1862,1866,1868,1879,1883,1886,1895,
+		1898,1905,1908,1912,1919
 	};
 
 	public static readonly ATN _ATN =

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -285,6 +285,7 @@ namespace Boo.Lang.Resources
 		public const string BooParser_DuplicateAccessor = "A property can only state one {0}";
 		public const string BooParser_KeywordAsIdentifier = "Illegal use of keyword '{0}' as identifier";
 		public const string BooParser_DuplicateDocstring = "A docstring can only be written once, either above the body or within it";
+		public const string BooParser_RefOnNonStruct = "Only a struct can be declared 'ref'";
 
 	}
 }

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -186,6 +186,11 @@ namespace Boo.Lang.Resources
         public const string BCE0181 = "Unsafe method calls returning a pointer are not valid in an async method";
 		public const string BCE0182 = "Type {0} does not contain a valid GetAwaiter method";
 		public const string BCE0183 = "Expression '{0}' does not support slicing.";
+		public const string BCE0190 = "Cannot box byref-like type '{0}': it has no conversion to '{1}'.";
+		public const string BCE0191 = "Byref-like type '{0}' cannot be a field of '{1}'.";
+		public const string BCE0192 = "Byref-like type '{0}' cannot be captured by a closure, a generator or an async method.";
+		public const string BCE0193 = "Byref-like type '{0}' cannot be the element type of an array.";
+		public const string BCE0194 = "Byref-like type '{0}' cannot be used as a generic argument.";
         public const string BCW0000 = "WARNING: {0}";
 		public const string BCW0001 = "WARNING: Type '{0}' does not provide an implementation for '{1}' and will be marked abstract.";
 		public const string BCW0002 = "WARNING: Statement modifiers have no effect in labels.";

--- a/tests/Boo.Lang.Parser.Tests/ParserCorpusTestFixture.boo
+++ b/tests/Boo.Lang.Parser.Tests/ParserCorpusTestFixture.boo
@@ -71,6 +71,11 @@ public class ParserCorpusTestFixture:
 		Unparseable.Add("tests/testcases/errors/docstring-written-twice.boo")
 		Unparseable.Add("tests/testcases/errors/single-error-on-missing-import-namespace.boo")
 		Unparseable.Add("tests/testcases/regression/BOO-779-3.boo")
+		Unparseable.Add("tests/testcases/byreflike/errors/ref-callable.boo")
+		Unparseable.Add("tests/testcases/byreflike/errors/ref-class.boo")
+		Unparseable.Add("tests/testcases/byreflike/errors/ref-enum.boo")
+		Unparseable.Add("tests/testcases/byreflike/errors/ref-interface.boo")
+		Unparseable.Add("tests/testcases/byreflike/errors/ref-nested-class.boo")
 
 		if File.Exists(ExclusionsPath):
 			NoFixedPoint = HashSet[of string](

--- a/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
@@ -818,6 +818,10 @@ class CompilerErrorsTestFixture(AbstractCompilerErrorsTestFixture):
 		RunCompilerTestCase("BCE0153-2.boo")
 
 	[Test]
+	def @BCE0153_3():
+		RunCompilerTestCase("BCE0153-3.boo")
+
+	[Test]
 	def @BCE0154_1():
 		RunCompilerTestCase("BCE0154-1.boo")
 

--- a/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
@@ -262,6 +262,10 @@ class CompilerErrorsTestFixture(AbstractCompilerErrorsTestFixture):
 		RunCompilerTestCase("BCE0053-3.boo")
 
 	[Test]
+	def @BCE0053_4():
+		RunCompilerTestCase("BCE0053-4.boo")
+
+	[Test]
 	def @BCE0057_1():
 		RunCompilerTestCase("BCE0057-1.boo")
 

--- a/tests/BooCompiler.Tests/Generated/RefStructsErrorsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/RefStructsErrorsTestFixture.generated.boo
@@ -26,6 +26,10 @@ class RefStructsErrorsTestFixture(AbstractCompilerErrorsTestFixture):
 		RunCompilerTestCase("async-span.boo")
 
 	[Test]
+	def @attribute_byreflike_field():
+		RunCompilerTestCase("attribute-byreflike-field.boo")
+
+	[Test]
 	def @box_argument():
 		RunCompilerTestCase("box-argument.boo")
 
@@ -112,6 +116,26 @@ class RefStructsErrorsTestFixture(AbstractCompilerErrorsTestFixture):
 	[Test]
 	def @readonlyspan_write():
 		RunCompilerTestCase("readonlyspan-write.boo")
+
+	[Test]
+	def @ref_callable():
+		RunCompilerTestCase("ref-callable.boo")
+
+	[Test]
+	def @ref_class():
+		RunCompilerTestCase("ref-class.boo")
+
+	[Test]
+	def @ref_enum():
+		RunCompilerTestCase("ref-enum.boo")
+
+	[Test]
+	def @ref_interface():
+		RunCompilerTestCase("ref-interface.boo")
+
+	[Test]
+	def @ref_nested_class():
+		RunCompilerTestCase("ref-nested-class.boo")
 
 	[Test]
 	def @static_byreflike_field():

--- a/tests/BooCompiler.Tests/Generated/RefStructsErrorsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/RefStructsErrorsTestFixture.generated.boo
@@ -1,0 +1,129 @@
+namespace BooCompiler.Tests
+
+import NUnit.Framework
+
+[TestFixture]
+class RefStructsErrorsTestFixture(AbstractCompilerErrorsTestFixture):
+
+	[Test]
+	def @array_builtin():
+		RunCompilerTestCase("array-builtin.boo")
+
+	[Test]
+	def @array_local():
+		RunCompilerTestCase("array-local.boo")
+
+	[Test]
+	def @array_return():
+		RunCompilerTestCase("array-return.boo")
+
+	[Test]
+	def @array_span():
+		RunCompilerTestCase("array-span.boo")
+
+	[Test]
+	def @async_span():
+		RunCompilerTestCase("async-span.boo")
+
+	[Test]
+	def @box_argument():
+		RunCompilerTestCase("box-argument.boo")
+
+	[Test]
+	def @box_array_element():
+		RunCompilerTestCase("box-array-element.boo")
+
+	[Test]
+	def @box_cast():
+		RunCompilerTestCase("box-cast.boo")
+
+	[Test]
+	def @box_concat():
+		RunCompilerTestCase("box-concat.boo")
+
+	[Test]
+	def @box_duck():
+		RunCompilerTestCase("box-duck.boo")
+
+	[Test]
+	def @box_inherited_member():
+		RunCompilerTestCase("box-inherited-member.boo")
+
+	[Test]
+	def @box_list():
+		RunCompilerTestCase("box-list.boo")
+
+	[Test]
+	def @box_return():
+		RunCompilerTestCase("box-return.boo")
+
+	[Test]
+	def @box_span():
+		RunCompilerTestCase("box-span.boo")
+
+	[Test]
+	def @box_trycast():
+		RunCompilerTestCase("box-trycast.boo")
+
+	[Test]
+	def @box_varargs():
+		RunCompilerTestCase("box-varargs.boo")
+
+	[Test]
+	def @closure_span():
+		RunCompilerTestCase("closure-span.boo")
+
+	[Test]
+	def @declared_box():
+		RunCompilerTestCase("declared-box.boo")
+
+	[Test]
+	def @declared_field():
+		RunCompilerTestCase("declared-field.boo")
+
+	[Test]
+	def @field_span():
+		RunCompilerTestCase("field-span.boo")
+
+	[Test]
+	def @generator_span():
+		RunCompilerTestCase("generator-span.boo")
+
+	[Test]
+	def @generic_declared_argument():
+		RunCompilerTestCase("generic-declared-argument.boo")
+
+	[Test]
+	def @generic_declared_box():
+		RunCompilerTestCase("generic-declared-box.boo")
+
+	[Test]
+	def @generic_span():
+		RunCompilerTestCase("generic-span.boo")
+
+	[Test]
+	def @readonlyspan_refarg():
+		RunCompilerTestCase("readonlyspan-refarg.boo")
+
+	[Test]
+	def @readonlyspan_refreturn_write():
+		RunCompilerTestCase("readonlyspan-refreturn-write.boo")
+
+	[Test]
+	def @readonlyspan_write():
+		RunCompilerTestCase("readonlyspan-write.boo")
+
+	[Test]
+	def @static_byreflike_field():
+		RunCompilerTestCase("static-byreflike-field.boo")
+
+	[Test]
+	def @typetest_span():
+		RunCompilerTestCase("typetest-span.boo")
+
+	[Test]
+	def @using_byreflike():
+		RunCompilerTestCase("using-byreflike.boo")
+
+	override protected def GetRelativeTestCasesPath() as string:
+		return "byreflike/errors"

--- a/tests/BooCompiler.Tests/Generated/RefStructsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/RefStructsTestFixture.generated.boo
@@ -6,6 +6,10 @@ import NUnit.Framework
 class RefStructsTestFixture(AbstractCompilerTestCase):
 
 	[Test]
+	def @attribute_byreflike():
+		RunCompilerTestCase("attribute-byreflike.boo")
+
+	[Test]
 	def @declare_byreflike():
 		RunCompilerTestCase("declare-byreflike.boo")
 

--- a/tests/BooCompiler.Tests/Generated/RefStructsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/RefStructsTestFixture.generated.boo
@@ -1,0 +1,81 @@
+namespace BooCompiler.Tests
+
+import NUnit.Framework
+
+[TestFixture]
+class RefStructsTestFixture(AbstractCompilerTestCase):
+
+	[Test]
+	def @declare_byreflike():
+		RunCompilerTestCase("declare-byreflike.boo")
+
+	[Test]
+	def @declared_interface():
+		RunCompilerTestCase("declared-interface.boo")
+
+	[Test]
+	def @declared_override():
+		RunCompilerTestCase("declared-override.boo")
+
+	[Test]
+	def @nested_byreflike():
+		RunCompilerTestCase("nested-byreflike.boo")
+
+	[Test]
+	def @span_compound():
+		RunCompilerTestCase("span-compound.boo")
+
+	[Test]
+	def @span_contexts():
+		RunCompilerTestCase("span-contexts.boo")
+
+	[Test]
+	def @span_foreach_contexts():
+		RunCompilerTestCase("span-foreach-contexts.boo")
+
+	[Test]
+	def @span_hello_world():
+		RunCompilerTestCase("span-hello-world.boo")
+
+	[Test]
+	def @span_hello_world2():
+		RunCompilerTestCase("span-hello-world2.boo")
+
+	[Test]
+	def @span_operators():
+		RunCompilerTestCase("span-operators.boo")
+
+	[Test]
+	def @span_refarg():
+		RunCompilerTestCase("span-refarg.boo")
+
+	[Test]
+	def @span_refproperty_write():
+		RunCompilerTestCase("span-refproperty-write.boo")
+
+	[Test]
+	def @span_refproperty():
+		RunCompilerTestCase("span-refproperty.boo")
+
+	[Test]
+	def @span_refreturn_write():
+		RunCompilerTestCase("span-refreturn-write.boo")
+
+	[Test]
+	def @span_refreturn():
+		RunCompilerTestCase("span-refreturn.boo")
+
+	[Test]
+	def @span_return_and_refparam():
+		RunCompilerTestCase("span-return-and-refparam.boo")
+
+	[Test]
+	def @span_write_param():
+		RunCompilerTestCase("span-write-param.boo")
+
+	[Test]
+	def @span_write():
+		RunCompilerTestCase("span-write.boo")
+
+	override protected def GetRelativeTestCasesPath() as string:
+		return "byreflike"

--- a/tests/BooCompiler.Tests/Generated/TypesIntegrationTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/TypesIntegrationTestFixture.generated.boo
@@ -762,6 +762,10 @@ class TypesIntegrationTestFixture(AbstractCompilerTestCase):
 		RunCompilerTestCase("properties-9.boo")
 
 	[Test]
+	def @refreturn_1():
+		RunCompilerTestCase("refreturn-1.boo")
+
+	[Test]
 	def @reserved_keywords_1():
 		RunCompilerTestCase("reserved-keywords-1.boo")
 

--- a/tests/BooCompiler.Tests/SmokeTest.boo
+++ b/tests/BooCompiler.Tests/SmokeTest.boo
@@ -307,6 +307,10 @@ print [| 42 |]"""
 		RunCompilerTestCase("enumeratoritemtype2.boo")
 
 	[Test]
+	def EnumeratorItemTypeForOverloadedGetEnumerator():
+		RunCompilerTestCase("enumeratoritemtype3.boo")
+
+	[Test]
 	def UnaryMinusWithLocal():
 		RunCompilerTestCase("unary0.boo")
 

--- a/tests/BooCompiler.Tests/VerificationQueue.boo
+++ b/tests/BooCompiler.Tests/VerificationQueue.boo
@@ -78,6 +78,11 @@ internal static class VerificationQueue:
 			startInfo.ArgumentList.Add("-r")
 			startInfo.ArgumentList.Add(Path.Combine(directory, "*.dll"))
 
+		# ilverify does not model ref safety for byreflike types, so it rejects
+		# any method handing back a Span whatever compiler emitted it.
+		startInfo.ArgumentList.Add("-g")
+		startInfo.ArgumentList.Add("ReturnPtrToStack")
+
 		using process = Process.Start(startInfo):
 			output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd()
 			process.WaitForExit()

--- a/tests/BooCompilerSupportingClasses/SupportingClasses/ByRef.cs
+++ b/tests/BooCompilerSupportingClasses/SupportingClasses/ByRef.cs
@@ -10,3 +10,19 @@ public class ByRef
 
 	public static void ReturnRef(object value, out object output) => output = value;
 }
+
+public class RefReturn
+{
+	private int _value;
+	private readonly int[] _items = new int[3];
+
+	public ref int Value => ref _value;
+
+	public ref readonly int ReadOnlyValue => ref _value;
+
+	public ref int Item(int index) => ref _items[index];
+
+	public int Read() => _value;
+
+	public int ReadItem(int index) => _items[index];
+}

--- a/tests/generate_regression.boo
+++ b/tests/generate_regression.boo
@@ -71,6 +71,10 @@ def Main(argv as (string)):
 	
 	GenerateTestFixture("unsafe/errors", "BooCompiler.Tests", "UnsafeErrorsTestFixture", "AbstractCompilerErrorsTestFixture")
 	
+	GenerateTestFixture("byreflike", "BooCompiler.Tests", "RefStructsTestFixture", "AbstractCompilerTestCase")
+	
+	GenerateTestFixture("byreflike/errors", "BooCompiler.Tests", "RefStructsErrorsTestFixture", "AbstractCompilerErrorsTestFixture")
+	
 
 def PortParserTestCases():
 """

--- a/tests/testcases/byreflike/attribute-byreflike.boo
+++ b/tests/testcases/byreflike/attribute-byreflike.boo
@@ -1,0 +1,15 @@
+"""
+5
+"""
+# 'ref struct' is the syntax, but the attribute it stands for still marks a type
+# on its own, which is how an external byreflike type arrives.
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+b = Buffer()
+b.Length = 5
+Console.WriteLine(b.Length)

--- a/tests/testcases/byreflike/declare-byreflike.boo
+++ b/tests/testcases/byreflike/declare-byreflike.boo
@@ -2,10 +2,8 @@
 5
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer:
+ref struct Buffer:
 	public Length as int
 
 b = Buffer()

--- a/tests/testcases/byreflike/declare-byreflike.boo
+++ b/tests/testcases/byreflike/declare-byreflike.boo
@@ -1,0 +1,13 @@
+"""
+5
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+b = Buffer()
+b.Length = 5
+Console.WriteLine(b.Length)

--- a/tests/testcases/byreflike/declared-interface.boo
+++ b/tests/testcases/byreflike/declared-interface.boo
@@ -2,13 +2,11 @@
 buf
 """
 import System
-import System.Runtime.CompilerServices
 
 interface INamed:
 	def Name() as string
 
-[IsByRefLike]
-struct Buffer(INamed):
+ref struct Buffer(INamed):
 	public Length as int
 	def Name() as string:
 		return "buf"

--- a/tests/testcases/byreflike/declared-interface.boo
+++ b/tests/testcases/byreflike/declared-interface.boo
@@ -1,0 +1,17 @@
+"""
+buf
+"""
+import System
+import System.Runtime.CompilerServices
+
+interface INamed:
+	def Name() as string
+
+[IsByRefLike]
+struct Buffer(INamed):
+	public Length as int
+	def Name() as string:
+		return "buf"
+
+b = Buffer()
+Console.WriteLine(b.Name())

--- a/tests/testcases/byreflike/declared-override.boo
+++ b/tests/testcases/byreflike/declared-override.boo
@@ -2,10 +2,8 @@
 Buffer(3)
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer:
+ref struct Buffer:
 	public Length as int
 	override def ToString() as string:
 		return "Buffer(${Length})"

--- a/tests/testcases/byreflike/declared-override.boo
+++ b/tests/testcases/byreflike/declared-override.boo
@@ -1,0 +1,15 @@
+"""
+Buffer(3)
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+	override def ToString() as string:
+		return "Buffer(${Length})"
+
+b = Buffer()
+b.Length = 3
+Console.WriteLine(b.ToString())

--- a/tests/testcases/byreflike/errors/array-builtin.boo
+++ b/tests/testcases/byreflike/errors/array-builtin.boo
@@ -1,0 +1,7 @@
+"""
+array-builtin.boo(6,10): BCE0193: Byref-like type 'System.Span[of int]' cannot be the element type of an array.
+"""
+import System
+
+a = array(Span[of int], 3)
+Console.WriteLine(a.Length)

--- a/tests/testcases/byreflike/errors/array-local.boo
+++ b/tests/testcases/byreflike/errors/array-local.boo
@@ -1,0 +1,7 @@
+"""
+array-local.boo(6,1): BCE0193: Byref-like type 'System.Span[of int]' cannot be the element type of an array.
+"""
+import System
+
+a as (Span[of int]) = null
+Console.WriteLine(a)

--- a/tests/testcases/byreflike/errors/array-return.boo
+++ b/tests/testcases/byreflike/errors/array-return.boo
@@ -1,0 +1,9 @@
+"""
+array-return.boo(6,15): BCE0193: Byref-like type 'System.Span[of int]' cannot be the element type of an array.
+"""
+import System
+
+def make() as (Span[of int]):
+	return null
+
+Console.WriteLine(make())

--- a/tests/testcases/byreflike/errors/array-span.boo
+++ b/tests/testcases/byreflike/errors/array-span.boo
@@ -1,0 +1,8 @@
+"""
+array-span.boo(7,8): BCE0193: Byref-like type 'System.ReadOnlySpan[of char]' cannot be the element type of an array.
+"""
+import System
+
+span = "Hello".AsSpan()
+arr = (span,)
+Console.WriteLine(arr.Length)

--- a/tests/testcases/byreflike/errors/async-span.boo
+++ b/tests/testcases/byreflike/errors/async-span.boo
@@ -1,0 +1,12 @@
+"""
+async-span.boo(7,13): BCE0192: Byref-like type 'System.ReadOnlySpan[of char]' cannot be captured by a closure, a generator or an async method.
+"""
+import System
+import System.Threading.Tasks
+
+[async] def Work() as Task:
+	span = "Hello".AsSpan()
+	await(Task.Delay(1))
+	Console.WriteLine(span.Length)
+
+Work().Wait()

--- a/tests/testcases/byreflike/errors/attribute-byreflike-field.boo
+++ b/tests/testcases/byreflike/errors/attribute-byreflike-field.boo
@@ -1,0 +1,15 @@
+"""
+attribute-byreflike-field.boo(13,12): BCE0191: Byref-like type 'Buffer' cannot be a field of 'Holder'.
+"""
+# The checks key off the attribute, not off the 'ref struct' spelling.
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+class Holder:
+	public b as Buffer
+
+Console.WriteLine(Holder())

--- a/tests/testcases/byreflike/errors/box-argument.boo
+++ b/tests/testcases/byreflike/errors/box-argument.boo
@@ -1,0 +1,10 @@
+"""
+box-argument.boo(10,6): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+def take(o as object):
+	Console.WriteLine(o)
+
+span = "Hello".AsSpan()
+take(span)

--- a/tests/testcases/byreflike/errors/box-array-element.boo
+++ b/tests/testcases/byreflike/errors/box-array-element.boo
@@ -1,0 +1,9 @@
+"""
+box-array-element.boo(8,8): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+span = "Hello".AsSpan()
+a = array(object, 1)
+a[0] = span
+Console.WriteLine(a[0])

--- a/tests/testcases/byreflike/errors/box-cast.boo
+++ b/tests/testcases/byreflike/errors/box-cast.boo
@@ -1,0 +1,7 @@
+"""
+box-cast.boo(7,19): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+span = "Hello".AsSpan()
+Console.WriteLine(cast(object, span))

--- a/tests/testcases/byreflike/errors/box-concat.boo
+++ b/tests/testcases/byreflike/errors/box-concat.boo
@@ -1,0 +1,8 @@
+"""
+box-concat.boo(7,11): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+span = "Hello".AsSpan()
+s = "x" + span
+Console.WriteLine(s)

--- a/tests/testcases/byreflike/errors/box-duck.boo
+++ b/tests/testcases/byreflike/errors/box-duck.boo
@@ -1,0 +1,8 @@
+"""
+box-duck.boo(7,13): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'duck'.
+"""
+import System
+
+span = "Hello".AsSpan()
+d as duck = span
+Console.WriteLine(d.Length)

--- a/tests/testcases/byreflike/errors/box-inherited-member.boo
+++ b/tests/testcases/byreflike/errors/box-inherited-member.boo
@@ -1,11 +1,9 @@
 """
-box-inherited-member.boo(12,29): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'System.ValueType'.
+box-inherited-member.boo(10,29): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'System.ValueType'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer:
+ref struct Buffer:
 	public Length as int
 
 b = Buffer()

--- a/tests/testcases/byreflike/errors/box-inherited-member.boo
+++ b/tests/testcases/byreflike/errors/box-inherited-member.boo
@@ -1,0 +1,12 @@
+"""
+box-inherited-member.boo(12,29): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'System.ValueType'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+b = Buffer()
+Console.WriteLine(b.ToString())

--- a/tests/testcases/byreflike/errors/box-list.boo
+++ b/tests/testcases/byreflike/errors/box-list.boo
@@ -1,0 +1,8 @@
+"""
+box-list.boo(7,6): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+span = "Hello".AsSpan()
+l = [span]
+Console.WriteLine(l.Count)

--- a/tests/testcases/byreflike/errors/box-return.boo
+++ b/tests/testcases/byreflike/errors/box-return.boo
@@ -1,0 +1,9 @@
+"""
+box-return.boo(7,26): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+def wrap() as object:
+	return "Hello".AsSpan()
+
+Console.WriteLine(wrap())

--- a/tests/testcases/byreflike/errors/box-span.boo
+++ b/tests/testcases/byreflike/errors/box-span.boo
@@ -1,0 +1,7 @@
+"""
+box-span.boo(6,33): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+boxed as object = "Hello".AsSpan()
+Console.WriteLine(boxed)

--- a/tests/testcases/byreflike/errors/box-trycast.boo
+++ b/tests/testcases/byreflike/errors/box-trycast.boo
@@ -1,11 +1,9 @@
 """
-box-trycast.boo(14,5): BCE0190: Cannot box byref-like type 'Res': it has no conversion to 'System.IDisposable'.
+box-trycast.boo(12,5): BCE0190: Cannot box byref-like type 'Res': it has no conversion to 'System.IDisposable'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Res(IDisposable):
+ref struct Res(IDisposable):
 	public N as int
 	def Dispose():
 		pass

--- a/tests/testcases/byreflike/errors/box-trycast.boo
+++ b/tests/testcases/byreflike/errors/box-trycast.boo
@@ -1,0 +1,15 @@
+"""
+box-trycast.boo(14,5): BCE0190: Cannot box byref-like type 'Res': it has no conversion to 'System.IDisposable'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Res(IDisposable):
+	public N as int
+	def Dispose():
+		pass
+
+r = Res()
+d = r as IDisposable
+Console.WriteLine(d)

--- a/tests/testcases/byreflike/errors/box-varargs.boo
+++ b/tests/testcases/byreflike/errors/box-varargs.boo
@@ -1,0 +1,10 @@
+"""
+box-varargs.boo(10,6): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+def show(*args as (object)):
+	Console.WriteLine(args.Length)
+
+span = "Hello".AsSpan()
+show(span)

--- a/tests/testcases/byreflike/errors/closure-span.boo
+++ b/tests/testcases/byreflike/errors/closure-span.boo
@@ -1,0 +1,8 @@
+"""
+closure-span.boo(1,1): BCE0192: Byref-like type 'System.ReadOnlySpan[of char]' cannot be captured by a closure, a generator or an async method.
+"""
+import System
+
+span = "Hello".AsSpan()
+f = { Console.WriteLine(span.Length) }
+f()

--- a/tests/testcases/byreflike/errors/declared-box.boo
+++ b/tests/testcases/byreflike/errors/declared-box.boo
@@ -1,11 +1,9 @@
 """
-declared-box.boo(11,25): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'object'.
+declared-box.boo(9,25): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'object'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer:
+ref struct Buffer:
 	public Length as int
 
 boxed as object = Buffer()

--- a/tests/testcases/byreflike/errors/declared-box.boo
+++ b/tests/testcases/byreflike/errors/declared-box.boo
@@ -1,0 +1,12 @@
+"""
+declared-box.boo(11,25): BCE0190: Cannot box byref-like type 'Buffer': it has no conversion to 'object'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+boxed as object = Buffer()
+Console.WriteLine(boxed)

--- a/tests/testcases/byreflike/errors/declared-field.boo
+++ b/tests/testcases/byreflike/errors/declared-field.boo
@@ -1,11 +1,9 @@
 """
-declared-field.boo(12,12): BCE0191: Byref-like type 'Buffer' cannot be a field of 'Holder'.
+declared-field.boo(10,12): BCE0191: Byref-like type 'Buffer' cannot be a field of 'Holder'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer:
+ref struct Buffer:
 	public Length as int
 
 class Holder:

--- a/tests/testcases/byreflike/errors/declared-field.boo
+++ b/tests/testcases/byreflike/errors/declared-field.boo
@@ -1,0 +1,14 @@
+"""
+declared-field.boo(12,12): BCE0191: Byref-like type 'Buffer' cannot be a field of 'Holder'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer:
+	public Length as int
+
+class Holder:
+	public b as Buffer
+
+Console.WriteLine(Holder())

--- a/tests/testcases/byreflike/errors/field-span.boo
+++ b/tests/testcases/byreflike/errors/field-span.boo
@@ -1,0 +1,9 @@
+"""
+field-span.boo(7,12): BCE0191: Byref-like type 'System.ReadOnlySpan[of char]' cannot be a field of 'Holder'.
+"""
+import System
+
+class Holder:
+	public s as ReadOnlySpan[of char]
+
+Console.WriteLine(Holder().s.Length)

--- a/tests/testcases/byreflike/errors/generator-span.boo
+++ b/tests/testcases/byreflike/errors/generator-span.boo
@@ -1,0 +1,11 @@
+"""
+generator-span.boo(6,5): BCE0192: Byref-like type 'System.ReadOnlySpan[of char]' cannot be captured by a closure, a generator or an async method.
+"""
+import System
+
+def gen():
+	span = "Hello".AsSpan()
+	yield span.Length
+
+for x in gen():
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/errors/generic-declared-argument.boo
+++ b/tests/testcases/byreflike/errors/generic-declared-argument.boo
@@ -1,12 +1,10 @@
 """
-generic-declared-argument.boo(12,9): BCE0194: Byref-like type 'Buffer[of int]' cannot be used as a generic argument.
+generic-declared-argument.boo(10,9): BCE0194: Byref-like type 'Buffer[of int]' cannot be used as a generic argument.
 """
 import System
 import System.Collections.Generic
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer[of T]:
+ref struct Buffer[of T]:
 	public Length as int
 
 l = List[of Buffer[of int]]()

--- a/tests/testcases/byreflike/errors/generic-declared-argument.boo
+++ b/tests/testcases/byreflike/errors/generic-declared-argument.boo
@@ -1,0 +1,13 @@
+"""
+generic-declared-argument.boo(12,9): BCE0194: Byref-like type 'Buffer[of int]' cannot be used as a generic argument.
+"""
+import System
+import System.Collections.Generic
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer[of T]:
+	public Length as int
+
+l = List[of Buffer[of int]]()
+Console.WriteLine(l.Count)

--- a/tests/testcases/byreflike/errors/generic-declared-box.boo
+++ b/tests/testcases/byreflike/errors/generic-declared-box.boo
@@ -1,11 +1,9 @@
 """
-generic-declared-box.boo(11,33): BCE0190: Cannot box byref-like type 'Buffer[of int]': it has no conversion to 'object'.
+generic-declared-box.boo(9,33): BCE0190: Cannot box byref-like type 'Buffer[of int]': it has no conversion to 'object'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Buffer[of T]:
+ref struct Buffer[of T]:
 	public Length as int
 
 boxed as object = Buffer[of int]()

--- a/tests/testcases/byreflike/errors/generic-declared-box.boo
+++ b/tests/testcases/byreflike/errors/generic-declared-box.boo
@@ -1,0 +1,12 @@
+"""
+generic-declared-box.boo(11,33): BCE0190: Cannot box byref-like type 'Buffer[of int]': it has no conversion to 'object'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Buffer[of T]:
+	public Length as int
+
+boxed as object = Buffer[of int]()
+Console.WriteLine(boxed)

--- a/tests/testcases/byreflike/errors/generic-span.boo
+++ b/tests/testcases/byreflike/errors/generic-span.boo
@@ -1,0 +1,8 @@
+"""
+generic-span.boo(7,9): BCE0194: Byref-like type 'System.ReadOnlySpan[of char]' cannot be used as a generic argument.
+"""
+import System
+import System.Collections.Generic
+
+l = List[of ReadOnlySpan[of char]]()
+Console.WriteLine(l.Count)

--- a/tests/testcases/byreflike/errors/readonlyspan-refarg.boo
+++ b/tests/testcases/byreflike/errors/readonlyspan-refarg.boo
@@ -1,0 +1,11 @@
+"""
+readonlyspan-refarg.boo(11,10): BCE0127: A ref or out argument must be an lvalue: '*span.get_Item(0)'
+readonlyspan-refarg.boo(11,5): BCE0017: The best overload for the method 'Readonlyspan_refargModule.bump(char)' is not compatible with the argument list '(char)'.
+"""
+import System
+
+def bump(ref c as char):
+	c = char('X')
+
+span = "Hi".AsSpan()
+bump(span[0])

--- a/tests/testcases/byreflike/errors/readonlyspan-refreturn-write.boo
+++ b/tests/testcases/byreflike/errors/readonlyspan-refreturn-write.boo
@@ -1,0 +1,7 @@
+"""
+readonlyspan-refreturn-write.boo(7,26): BCE0049: Expression 'span.GetPinnableReference()' cannot be assigned to.
+"""
+import System
+
+span = "Hi".AsSpan()
+span.GetPinnableReference() = char('X')

--- a/tests/testcases/byreflike/errors/readonlyspan-write.boo
+++ b/tests/testcases/byreflike/errors/readonlyspan-write.boo
@@ -1,0 +1,7 @@
+"""
+readonlyspan-write.boo(7,5): BCE0053: Property 'System.ReadOnlySpan[of char].Item' is read only.
+"""
+import System
+
+span = "Hi".AsSpan()
+span[0] = char('X')

--- a/tests/testcases/byreflike/errors/ref-callable.boo
+++ b/tests/testcases/byreflike/errors/ref-callable.boo
@@ -1,0 +1,4 @@
+"""
+ref-callable.boo(4,1): BCE0044: Only a struct can be declared 'ref'.
+"""
+ref callable Foo(x as int) as int

--- a/tests/testcases/byreflike/errors/ref-class.boo
+++ b/tests/testcases/byreflike/errors/ref-class.boo
@@ -1,0 +1,5 @@
+"""
+ref-class.boo(4,1): BCE0044: Only a struct can be declared 'ref'.
+"""
+ref class Foo:
+	pass

--- a/tests/testcases/byreflike/errors/ref-enum.boo
+++ b/tests/testcases/byreflike/errors/ref-enum.boo
@@ -1,0 +1,5 @@
+"""
+ref-enum.boo(4,1): BCE0044: Only a struct can be declared 'ref'.
+"""
+ref enum Foo:
+	A

--- a/tests/testcases/byreflike/errors/ref-interface.boo
+++ b/tests/testcases/byreflike/errors/ref-interface.boo
@@ -1,0 +1,5 @@
+"""
+ref-interface.boo(4,1): BCE0044: Only a struct can be declared 'ref'.
+"""
+ref interface Foo:
+	def Bar()

--- a/tests/testcases/byreflike/errors/ref-nested-class.boo
+++ b/tests/testcases/byreflike/errors/ref-nested-class.boo
@@ -1,0 +1,6 @@
+"""
+ref-nested-class.boo(5,5): BCE0044: Only a struct can be declared 'ref'.
+"""
+class Outer:
+	ref class Inner:
+		pass

--- a/tests/testcases/byreflike/errors/static-byreflike-field.boo
+++ b/tests/testcases/byreflike/errors/static-byreflike-field.boo
@@ -1,11 +1,9 @@
 """
-static-byreflike-field.boo(9,19): BCE0191: Byref-like type 'System.Span[of int]' cannot be a field of 'Wrapper'.
+static-byreflike-field.boo(7,19): BCE0191: Byref-like type 'System.Span[of int]' cannot be a field of 'Wrapper'.
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Wrapper:
+ref struct Wrapper:
 	public static s as Span[of int]
 
 Console.WriteLine(Wrapper.s.Length)

--- a/tests/testcases/byreflike/errors/static-byreflike-field.boo
+++ b/tests/testcases/byreflike/errors/static-byreflike-field.boo
@@ -1,0 +1,11 @@
+"""
+static-byreflike-field.boo(9,19): BCE0191: Byref-like type 'System.Span[of int]' cannot be a field of 'Wrapper'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Wrapper:
+	public static s as Span[of int]
+
+Console.WriteLine(Wrapper.s.Length)

--- a/tests/testcases/byreflike/errors/typetest-span.boo
+++ b/tests/testcases/byreflike/errors/typetest-span.boo
@@ -1,0 +1,7 @@
+"""
+typetest-span.boo(7,24): BCE0190: Cannot box byref-like type 'System.ReadOnlySpan[of char]': it has no conversion to 'object'.
+"""
+import System
+
+span = "Hello".AsSpan()
+Console.WriteLine(span isa object)

--- a/tests/testcases/byreflike/errors/using-byreflike.boo
+++ b/tests/testcases/byreflike/errors/using-byreflike.boo
@@ -1,0 +1,14 @@
+"""
+using-byreflike.boo(13,9): BCE0190: Cannot box byref-like type 'Res': it has no conversion to 'System.IDisposable'.
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Res(IDisposable):
+	public N as int
+	def Dispose():
+		Console.WriteLine("disposed")
+
+using r = Res():
+	Console.WriteLine("body")

--- a/tests/testcases/byreflike/nested-byreflike.boo
+++ b/tests/testcases/byreflike/nested-byreflike.boo
@@ -3,10 +3,8 @@
 1
 """
 import System
-import System.Runtime.CompilerServices
 
-[IsByRefLike]
-struct Wrapper:
+ref struct Wrapper:
 	public s as Span[of int]
 
 buf = array(int, 3)

--- a/tests/testcases/byreflike/nested-byreflike.boo
+++ b/tests/testcases/byreflike/nested-byreflike.boo
@@ -1,0 +1,17 @@
+"""
+3
+1
+"""
+import System
+import System.Runtime.CompilerServices
+
+[IsByRefLike]
+struct Wrapper:
+	public s as Span[of int]
+
+buf = array(int, 3)
+buf[0] = 1
+w = Wrapper()
+w.s = buf.AsSpan()
+Console.WriteLine(w.s.Length)
+Console.WriteLine(w.s[0])

--- a/tests/testcases/byreflike/span-compound.boo
+++ b/tests/testcases/byreflike/span-compound.boo
@@ -1,0 +1,11 @@
+"""
+15
+20
+"""
+import System
+
+buf = (10, 20)
+span = buf.AsSpan()
+span[0] += 5
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-contexts.boo
+++ b/tests/testcases/byreflike/span-contexts.boo
@@ -1,0 +1,14 @@
+"""
+v=2
+2
+2
+2
+"""
+import System
+
+buf = (1, 2)
+span = buf.AsSpan()
+Console.WriteLine("v=${span[1]}")
+Console.WriteLine(span[1].ToString())
+Console.WriteLine(cast(long, span[1]))
+Console.WriteLine("{0}", span[1])

--- a/tests/testcases/byreflike/span-foreach-contexts.boo
+++ b/tests/testcases/byreflike/span-foreach-contexts.boo
@@ -1,0 +1,19 @@
+"""
+H
+i
+c=H
+c=i
+-1
+-2
+"""
+import System
+
+for c in "Hi".AsSpan():
+	Console.WriteLine(c.ToString())
+
+for c in "Hi".AsSpan():
+	Console.WriteLine("c=${c}")
+
+buf = (1, 2)
+for v in buf.AsSpan():
+	Console.WriteLine(-v)

--- a/tests/testcases/byreflike/span-hello-world.boo
+++ b/tests/testcases/byreflike/span-hello-world.boo
@@ -1,0 +1,10 @@
+"""
+Hello, World!
+"""
+
+import System
+
+var span = "Hello, World!".AsSpan()
+for i in range(span.Length):
+	Console.Write(span[i])
+Console.WriteLine()

--- a/tests/testcases/byreflike/span-hello-world2.boo
+++ b/tests/testcases/byreflike/span-hello-world2.boo
@@ -1,0 +1,10 @@
+"""
+Hello, World!
+"""
+
+import System
+
+var span = "Hello, World!".AsSpan()
+for letter in span:
+	Console.Write(letter)
+Console.WriteLine()

--- a/tests/testcases/byreflike/span-operators.boo
+++ b/tests/testcases/byreflike/span-operators.boo
@@ -1,0 +1,16 @@
+"""
+False
+True
+True
+-2
+-3
+"""
+import System
+
+buf = (1, 2)
+span = buf.AsSpan()
+Console.WriteLine(span[0] > 5)
+Console.WriteLine(span[0] == 1)
+Console.WriteLine(span[1] > span[0])
+Console.WriteLine(-span[1])
+Console.WriteLine(~span[1])

--- a/tests/testcases/byreflike/span-refarg.boo
+++ b/tests/testcases/byreflike/span-refarg.boo
@@ -1,0 +1,14 @@
+"""
+2
+8
+"""
+import System
+
+def bump(ref x as int):
+	x += 1
+
+buf = (1, 8)
+span = buf.AsSpan()
+bump(span[0])
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-refproperty-write.boo
+++ b/tests/testcases/byreflike/span-refproperty-write.boo
@@ -1,0 +1,13 @@
+"""
+42
+8
+"""
+import System
+
+buf = (7, 8)
+span = buf.AsSpan()
+e = span.GetEnumerator()
+e.MoveNext()
+e.Current = 42
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-refproperty.boo
+++ b/tests/testcases/byreflike/span-refproperty.boo
@@ -1,0 +1,11 @@
+"""
+H
+H
+"""
+import System
+
+span = "Hi".AsSpan()
+e = span.GetEnumerator()
+e.MoveNext()
+Console.WriteLine(e.Current)
+Console.WriteLine(e.Current.ToString())

--- a/tests/testcases/byreflike/span-refreturn-write.boo
+++ b/tests/testcases/byreflike/span-refreturn-write.boo
@@ -1,0 +1,11 @@
+"""
+99
+8
+"""
+import System
+
+buf = (7, 8)
+span = buf.AsSpan()
+span.GetPinnableReference() = 99
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-refreturn.boo
+++ b/tests/testcases/byreflike/span-refreturn.boo
@@ -5,7 +5,7 @@
 """
 import System
 
-buf = (7, 8)
+buf = (7, 99)
 span = buf.AsSpan()
 Console.WriteLine(span.GetPinnableReference())
 Console.WriteLine(span.GetPinnableReference().ToString())

--- a/tests/testcases/byreflike/span-refreturn.boo
+++ b/tests/testcases/byreflike/span-refreturn.boo
@@ -1,0 +1,12 @@
+"""
+7
+7
+8
+"""
+import System
+
+buf = (7, 8)
+span = buf.AsSpan()
+Console.WriteLine(span.GetPinnableReference())
+Console.WriteLine(span.GetPinnableReference().ToString())
+Console.WriteLine(span.GetPinnableReference() + 1)

--- a/tests/testcases/byreflike/span-return-and-refparam.boo
+++ b/tests/testcases/byreflike/span-return-and-refparam.boo
@@ -1,0 +1,17 @@
+"""
+2
+8
+"""
+import System
+
+def whole(a as (int)) as Span[of int]:
+	return a.AsSpan()
+
+def bump(ref s as Span[of int]):
+	s[0] = s[0] + 1
+
+buf = (1, 8)
+s = whole(buf)
+bump(s)
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-write-param.boo
+++ b/tests/testcases/byreflike/span-write-param.boo
@@ -1,0 +1,15 @@
+"""
+7
+7
+7
+"""
+import System
+
+def fill(s as Span[of int], v as int):
+	for i in range(s.Length):
+		s[i] = v
+
+buf = array(int, 3)
+fill(buf.AsSpan(), 7)
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/byreflike/span-write.boo
+++ b/tests/testcases/byreflike/span-write.boo
@@ -1,0 +1,13 @@
+"""
+1
+2
+3
+"""
+import System
+
+buf = array(int, 3)
+span = buf.AsSpan()
+for i in range(span.Length):
+	span[i] = i + 1
+for x in buf:
+	Console.WriteLine(x)

--- a/tests/testcases/compilation/enumeratoritemtype3.boo
+++ b/tests/testcases/compilation/enumeratoritemtype3.boo
@@ -1,0 +1,13 @@
+"""
+2
+"""
+class Foo:
+	def GetEnumerator[of T]() as System.Collections.IEnumerator: #generic method GetEnumerator must be ignored
+		pass
+	def GetEnumerator(_ as int) as int: #ignored GetEnumerator with parameter(s)
+		pass
+	def GetEnumerator() as System.Collections.Generic.IEnumerator[of int]: #this one will be selected
+		yield 1
+
+for i in Foo():
+	print(i*2) # i is declared as int

--- a/tests/testcases/errors/BCE0053-4.boo
+++ b/tests/testcases/errors/BCE0053-4.boo
@@ -1,0 +1,7 @@
+"""
+BCE0053-4.boo(7,1): BCE0053: Property 'BooCompiler.Tests.SupportingClasses.RefReturn.ReadOnlyValue' is read only.
+"""
+import BooCompiler.Tests.SupportingClasses
+
+r = RefReturn()
+r.ReadOnlyValue = 3

--- a/tests/testcases/errors/BCE0153-3.boo
+++ b/tests/testcases/errors/BCE0153-3.boo
@@ -1,0 +1,8 @@
+"""
+BCE0153-3.boo(6,2): BCE0153: 'System.AttributeUsageAttribute' can be applied on one of these targets only : Class.
+"""
+import System
+
+[AttributeUsage(AttributeTargets.All)]
+struct AStructIsNotAClass:
+	public a as int

--- a/tests/testcases/integration/types/refreturn-1.boo
+++ b/tests/testcases/integration/types/refreturn-1.boo
@@ -1,0 +1,21 @@
+"""
+42
+7
+7
+5
+7
+"""
+import BooCompiler.Tests.SupportingClasses
+
+r = RefReturn()
+
+r.Item(0) = 42
+print r.ReadItem(0)
+
+r.Value = 7
+print r.Read()
+print r.Value
+
+ByRef.SetValue(5, r.Item(1))
+print r.ReadItem(1)
+print r.ReadOnlyValue


### PR DESCRIPTION
## Support byreflike types

Adds `Span`/`ReadOnlySpan` support to the compiler: byreflike values are tracked through the type system, the constructs that would move one to the heap are rejected, and the calls and stores they need are emitted.

Builds on @masonwheeler's `feature/ref-structs`. The testcases, `EmitConstrained` helper and `GetExplicitEnumeratorItemType` are largely the same with some modifications.

## Limitations:

A ref-returning method can be passed to a ref parameter; a ref-returning property cannot.

```
ByRef.SetValue(5, r.Item(1))   # works
ByRef.SetValue(5, r.Value)     # BCE0017
```

## References:

- https://github.com/dotnet/csharplang/blob/main/proposals/csharp-7.2/span-safety.md
- https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/ref-struct
- https://learn.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.isbyreflikeattribute?view=net-10.0
- https://github.com/dotnet/csharplang/blob/main/proposals/csharp-11.0/low-level-struct-improvements.md