### PR TITLE
fix(Compiler): fill defaults on constructor calls

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
@@ -4502,9 +4502,9 @@ namespace Boo.Lang.Compiler.Steps
 		/// to supply, so that every step after this one sees an ordinary call
 		/// with nothing missing.
 		/// </summary>
-		private void FillOmittedArguments(MethodInvocationExpression node, IMethod method)
+		private void FillOmittedArguments(MethodInvocationExpression node, IEntityWithParameters callable)
 		{
-			var parameters = method.GetParameters();
+			var parameters = callable.GetParameters();
 			if (node.Arguments.Count >= parameters.Length)
 				return;
 
@@ -4917,6 +4917,9 @@ namespace Boo.Lang.Compiler.Steps
 
 		void BindConstructorInvocation(MethodInvocationExpression node, IConstructor ctor)
 		{
+			// A constructor takes its defaults the same way a method does.
+			FillOmittedArguments(node, ctor);
+
 			// rebind the target now we know
 			// it is a constructor call
 			Bind(node.Target, ctor);
@@ -5510,7 +5513,9 @@ namespace Boo.Lang.Compiler.Steps
 				return;
 
 			IParameter[] parameters = target.GetSignature().Parameters;
-			for (int i = 0; i < parameters.Length; ++i) {
+			// Only the arguments the caller wrote are here to wrap.
+			var supplied = Math.Min(parameters.Length, args.Count);
+			for (int i = 0; i < supplied; ++i) {
 				if (!TypeSystemServices.IsNullable(parameters[i].Type))
 					continue;
 				if (TypeSystemServices.IsNullable(GetExpressionType(args[i])))

--- a/tests/BooCompiler.Tests/Generated/OptionalParametersIntegrationTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/OptionalParametersIntegrationTestFixture.generated.boo
@@ -30,6 +30,10 @@ class OptionalParametersIntegrationTestFixture(AbstractCompilerTestCase):
 		RunCompilerTestCase("omitted-argument-still-runs.boo")
 
 	[Test]
+	def @nullable_omitted_argument():
+		RunCompilerTestCase("nullable-omitted-argument.boo")
+
+	[Test]
 	def @partially_supplied_defaults():
 		RunCompilerTestCase("partially-supplied-defaults.boo")
 

--- a/tests/BooCompilerSupportingClasses/SupportingClasses/OptionalParameters.cs
+++ b/tests/BooCompilerSupportingClasses/SupportingClasses/OptionalParameters.cs
@@ -39,8 +39,17 @@ public class OptionalParameters
 	// A struct default arrives as null rather than a value.
 	public static string Token(CancellationToken token = default) => token.CanBeCanceled.ToString();
 
+	public static string Nullable(int a, int? b = null) => $"{a},{b?.ToString() ?? "none"}";
+
 	// An exact overload must beat one that needs a default filled in.
 	public static string Prefer(int a) => "exact";
 
 	public static string Prefer(int a, int b = 2) => "default";
+}
+
+public class OptionalNullableConstructor
+{
+	public string Description { get; }
+
+	public OptionalNullableConstructor(int a, int? b = null) => Description = $"{a},{b?.ToString() ?? "none"}";
 }

--- a/tests/testcases/integration/optional-parameters/nullable-omitted-argument.boo
+++ b/tests/testcases/integration/optional-parameters/nullable-omitted-argument.boo
@@ -1,0 +1,15 @@
+"""
+1,none
+1,2
+3,none
+3,4
+"""
+import BooCompiler.Tests.SupportingClasses from BooCompilerSupportingClasses
+
+# An optional parameter that is also nullable, left out and supplied, on a
+# static method and on a constructor. Constructors resolve on their own path,
+# so a method-only test leaves that path uncovered.
+print OptionalParameters.Nullable(1)
+print OptionalParameters.Nullable(1, 2)
+print OptionalNullableConstructor(3).Description
+print OptionalNullableConstructor(3, 4).Description


### PR DESCRIPTION
Follow-up to #232.

`BindConstructorInvocation` never called `FillOmittedArguments`, so `OptionalNullableConstructor(3)` against `(int a, int? b = null)` failed with `BCE0055: Internal compiler error: Index was outside the bounds of the array` instead of resolving.

- `FillOmittedArguments` takes `IEntityWithParameters`, so a constructor fills defaults the same way a method does
- the nullable wrapping in `ProcessMethodBodies` walked the parameter list while indexing the arguments, running off the end when one was left out
