### PR TITLE
feat(Extensions): add a Json literal metamethod

### DIFF
--- a/src/Boo.Lang.Extensions/MetaMethods/Json.boo
+++ b/src/Boo.Lang.Extensions/MetaMethods/Json.boo
@@ -1,0 +1,79 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace Boo.Lang.Extensions
+
+import System.Linq.Enumerable
+import Boo.Lang.Compiler
+import Boo.Lang.Compiler.Ast
+import Boo.Lang.Compiler.TypeSystem
+import Boo.Lang.Environments
+
+[Meta(ResolveArgs: true)]
+def Json(value as Expression) as Expression:
+"""
+Writes a Boo literal as the System.Text.Json tree it describes.
+
+A hash literal becomes a JsonObject and a list literal a JsonArray. A node
+built elsewhere is taken as it stands, and anything else converts itself.
+"""
+	return JsonObj(value) if value isa HashLiteralExpression
+	return JsonArr(value) if value isa ListLiteralExpression
+	return value if IsNode(value)
+	return [| System.Text.Json.Nodes.JsonValue.Create($value) |].withLexicalInfoFrom(value)
+
+private def IsNode(value as Expression) as bool:
+	# JsonValue.Create takes a value, not a node.
+	type = value.ExpressionType
+	return false if type is null
+	return my(TypeSystemServices).Map(typeof(System.Text.Json.Nodes.JsonNode)).IsAssignableFrom(type)
+
+private def JsonArr(value as ListLiteralExpression) as Expression:
+	# JsonArray takes its items as a params array, so they are its arguments.
+	call as MethodInvocationExpression = [| System.Text.Json.Nodes.JsonArray() |].withLexicalInfoFrom(value)
+	call.Arguments.AddRange(value.Items.Select(Json))
+	return call
+
+private def JsonObj(value as HashLiteralExpression) as Expression:
+	# JsonObject takes one IEnumerable of pairs, not a pair per argument.
+	if value.Items.Count == 0:
+		empty = [| array(System.Collections.Generic.KeyValuePair[of string, System.Text.Json.Nodes.JsonNode], 0) |]
+		return [| System.Text.Json.Nodes.JsonObject($empty) |].withLexicalInfoFrom(value)
+
+	pairs = ArrayLiteralExpression()
+	pairs.Items.AddRange(value.Items.Select(JsonPair))
+	return [| System.Text.Json.Nodes.JsonObject($pairs) |].withLexicalInfoFrom(value)
+
+private def JsonPair(pair as ExpressionPair) as Expression:
+	if pair.First isa LiteralExpression and not pair.First isa StringLiteralExpression:
+		# What a meta method raises reaches the reader as an internal error.
+		my(CompilerErrorCollection).Add(
+			CompilerErrorFactory.CustomError(pair.First, "A JSON key has to be a string."))
+		return [| null |].withLexicalInfoFrom(pair)
+	written = Json(pair.Second)
+	return [| System.Collections.Generic.KeyValuePair[of string, System.Text.Json.Nodes.JsonNode]($(pair.First), $written) |].withLexicalInfoFrom(pair)

--- a/tests/BooCompiler.Tests/JsonMetaMethodTest.boo
+++ b/tests/BooCompiler.Tests/JsonMetaMethodTest.boo
@@ -1,0 +1,120 @@
+namespace BooCompiler.Tests
+
+import System
+import System.IO
+import Boo.Lang.Compiler
+import Boo.Lang.Compiler.IO
+import Boo.Lang.Compiler.Pipelines
+import NUnit.Framework
+
+[TestFixture]
+class JsonMetaMethodTest:
+"""
+The Json meta method, which writes a Boo literal as a System.Text.Json tree.
+
+The source is compiled and run, since what matters is the JSON that comes
+out, not the shape of the tree the meta method returned.
+"""
+
+	private def Run(code as string) as string:
+		compiler = BooCompiler()
+		compiler.Parameters.Input.Add(StringInput("json", code))
+		compiler.Parameters.Pipeline = CompileToMemory()
+		compiler.Parameters.References.Add(typeof(Boo.Lang.Extensions.PrintMacro).Assembly)
+		compiler.Parameters.References.Add(typeof(System.Text.Json.Nodes.JsonNode).Assembly)
+		context = compiler.Run()
+		Assert.AreEqual(0, context.Errors.Count, Verbose(context.Errors))
+
+		written = StringWriter()
+		before = Console.Out
+		Console.SetOut(written)
+		try:
+			context.GeneratedAssembly.EntryPoint.Invoke(null, (null,))
+		ensure:
+			Console.SetOut(before)
+		return written.ToString().Trim()
+
+	private def Verbose(errors as Boo.Lang.Compiler.CompilerErrorCollection) as string:
+		written = System.Text.StringBuilder()
+		for error as Boo.Lang.Compiler.CompilerError in errors:
+			written.AppendLine(error.ToString(true))
+			inner = error.InnerException
+			while inner is not null:
+				written.AppendLine("  inner: ${inner.GetType().Name}: ${inner.Message}")
+				written.AppendLine("  at: ${inner.StackTrace}")
+				inner = inner.InnerException
+		return written.ToString()
+
+	private def Errors(code as string) as string:
+		compiler = BooCompiler()
+		compiler.Parameters.Input.Add(StringInput("json", code))
+		compiler.Parameters.Pipeline = ResolveExpressions(BreakOnErrors: false)
+		compiler.Parameters.References.Add(typeof(Boo.Lang.Extensions.PrintMacro).Assembly)
+		compiler.Parameters.References.Add(typeof(System.Text.Json.Nodes.JsonNode).Assembly)
+		return compiler.Run().Errors.ToString()
+
+	[Test]
+	def WritesAHashLiteralAsAnObject():
+		assert '{"a":1}' == Run("print Json({'a': 1}).ToJsonString()")
+
+	[Test]
+	def WritesAListLiteralAsAnArray():
+		assert '[1,2,3]' == Run("print Json([1, 2, 3]).ToJsonString()")
+
+	[Test]
+	def WritesWhatIsNested():
+		assert '{"a":{"b":[1]}}' == Run("print Json({'a': {'b': [1]}}).ToJsonString()")
+
+	[Test]
+	def WritesAnEmptyObjectAndArray():
+		assert '{}' == Run("print Json({}).ToJsonString()")
+		assert '[]' == Run("print Json([]).ToJsonString()")
+
+	[Test]
+	def WritesTheKindsOfValueJsonHas():
+		assert '{"s":"x","n":2,"b":true}' == Run("print Json({'s': 'x', 'n': 2, 'b': true}).ToJsonString()")
+
+	[Test]
+	def RefusesAKeyThatIsNotAString():
+		assert "A JSON key has to be a string." in Errors("print Json({1: 'a'}).ToJsonString()")
+
+	[Test]
+	def TakesANodeSomethingElseAlreadyBuilt():
+		code = """
+import System.Text.Json.Nodes
+inner = JsonObject()
+inner['b'] = 1
+print Json({'a': inner}).ToJsonString()
+"""
+		assert '{"a":{"b":1}}' == Run(code)
+
+	[Test]
+	def TakesANodeInsideAnArray():
+		code = """
+import System.Text.Json.Nodes
+print Json([JsonArray(), 2]).ToJsonString()
+"""
+		assert '[[],2]' == Run(code)
+
+	[Test]
+	def WritesWhateverAnItemEvaluatesTo():
+		code = """
+def Eight():
+	return '8'
+
+value = 3
+print Json([1, 2, value, Eight()]).ToJsonString()
+"""
+		assert '[1,2,3,"8"]' == Run(code)
+
+	[Test]
+	def WritesWhateverAValueEvaluatesTo():
+		code = """
+def Name():
+	return 'boo'
+
+count = 3
+print Json({'name': Name(), 'count': count + 1}).ToJsonString()
+"""
+		assert '{"name":"boo","count":4}' == Run(code)
+


### PR DESCRIPTION
Adds the `Json()` metamethod discussed in Discord, so building a
System.Text.Json tree reads like a literal instead of a pile of
dictionary assignments.

```boo
Json({ "name": "boo", "items": [1, 2, three, Four()] })
```

Needed #239 to land to work.