### PR TITLE
refactor(Interpreter): move code completion into its own class

### DIFF
--- a/src/Boo.Lang.Interpreter/AbstractInterpreter.boo
+++ b/src/Boo.Lang.Interpreter/AbstractInterpreter.boo
@@ -162,29 +162,7 @@ class AbstractInterpreter:
 			compiler.Parameters.Input.Clear()
 			
 	private def FilterSuggestions(code as string, entity as IEntity) as (IEntity):
-		ns = entity as INamespace
-		return array(IEntity, 0) if ns is null
-		return GetChildNamespaces(ns) if code.StartsWith("import ")
-		return FilteredMembers(Boo.Lang.Compiler.TypeSystem.Services.MemberCollector.CollectAllMembers(ns))
-		
-	private def FilteredMembers(members as (IEntity)):
-		return array(
-				item
-				for item in members
-				unless IsSpecial(item) or not IsPublic(item))
-
-	private def IsSpecial(entity as IEntity):
-		for prefix in ".", "___", "add_", "remove_", "raise_", "get_", "set_":
-			return true if entity.Name.StartsWith(prefix)
-			
-	private def IsPublic(entity as IEntity):
-		member = entity as IMember
-		return member is null or member.IsPublic
-		
-	private def GetChildNamespaces(parent as INamespace):
-		return array(member
-					for member in parent.GetMembers()
-					if member.EntityType == EntityType.Namespace)
+		return CodeCompletion.SuggestionsFor(entity, code.StartsWith("import "))
 			
 	private def PreProcessImportLine(code as string):
 		match = @/^\s*import\s+((\w|\.)+)\s*$/.Match(code)
@@ -600,20 +578,3 @@ class AbstractInterpreter:
 		override def Run():
 			CompileUnit.Modules[0].Imports.ExtendWithClones(_imports)
 
-	class FindCodeCompleteSuggestion(Steps.AbstractVisitorCompilerStep):
-		
-		override def Run():
-			Visit(CompileUnit)
-		
-		override def LeaveMemberReferenceExpression(node as MemberReferenceExpression):
-			if "__codecomplete__" == node.Name:
-				suggestion as IEntity
-				target = node.Target
-				if target.ExpressionType is not null:									
-					suggestion = target.ExpressionType
-				else:
-					suggestion = GetOptionalEntity(target)
-				if suggestion is not null and suggestion.EntityType != EntityType.Error:
-					_context["suggestion"] = suggestion
-					// TODO: use target to display static members only for type reference expressions
-					_context["target"] = target

--- a/src/Boo.Lang.Interpreter/CodeCompletion.boo
+++ b/src/Boo.Lang.Interpreter/CodeCompletion.boo
@@ -1,0 +1,105 @@
+#region license
+// Copyright (c) 2026 the Boo contributors
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+//     * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//     * Neither the name of Rodrigo B. de Oliveira nor the names of its
+//     contributors may be used to endorse or promote products derived from this
+//     software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#endregion
+
+namespace Boo.Lang.Interpreter
+
+import Boo.Lang.Compiler.Ast
+import Boo.Lang.Compiler.Steps
+import Boo.Lang.Compiler.TypeSystem
+import Boo.Lang.Compiler.TypeSystem.Services
+
+class FindCodeCompleteSuggestion(AbstractVisitorCompilerStep):
+"""
+Resolves the marker left where the cursor was.
+
+The code handed to the compiler has the name being typed replaced by the
+marker, so binding it says what the thing before the dot is, and that is what
+the suggestions come from.
+"""
+
+	public static final Marker = "__codecomplete__"
+
+	override def Run():
+		Visit(CompileUnit)
+
+	override def LeaveMemberReferenceExpression(node as MemberReferenceExpression):
+		if Marker == node.Name:
+			suggestion as IEntity
+			target = node.Target
+			if target.ExpressionType is not null:
+				suggestion = target.ExpressionType
+			else:
+				suggestion = TypeSystemServices.GetOptionalEntity(target)
+			if suggestion is not null and suggestion.EntityType != EntityType.Error:
+				_context["suggestion"] = suggestion
+				// TODO: use target to display static members only for type reference expressions
+				_context["target"] = target
+				// What the cursor sits inside decides which members it may reach.
+				_context["scope"] = node.GetAncestor[of TypeDefinition]()
+
+static class CodeCompletion:
+"""What is worth offering for an entity the marker resolved to."""
+
+	def SuggestionsFor(entity as IEntity, namespacesOnly as bool, scope as TypeDefinition) as (IEntity):
+		ns = entity as INamespace
+		return array(IEntity, 0) if ns is null
+		return ChildNamespaces(ns) if namespacesOnly
+		return Members(MemberCollector.CollectAllMembers(ns), Checker(scope))
+
+	def SuggestionsFor(entity as IEntity, namespacesOnly as bool) as (IEntity):
+		return SuggestionsFor(entity, namespacesOnly, null)
+
+	private def Checker(scope as TypeDefinition) as IAccessibilityChecker:
+	"""Without a scope, only the public surface is reachable."""
+		return AccessibilityChecker.Global if scope is null or not scope.Entity isa IType
+		return AccessibilityChecker(scope)
+
+	private def Members(members as (IEntity), checker as IAccessibilityChecker) as (IEntity):
+		return array(
+				item
+				for item in members
+				unless IsSpecial(item) or not IsVisible(item, checker))
+
+	private def ChildNamespaces(parent as INamespace) as (IEntity):
+		return array(member
+					for member in parent.GetMembers()
+					if member.EntityType == EntityType.Namespace)
+
+	def IsSpecial(entity as IEntity) as bool:
+		for prefix in ".", "___", "add_", "remove_", "raise_", "get_", "set_":
+			return true if entity.Name.StartsWith(prefix)
+		return false
+
+	private def IsVisible(entity as IEntity, checker as IAccessibilityChecker) as bool:
+		accessible = entity as IAccessibleMember
+		return checker.IsAccessible(accessible) if accessible is not null
+		return IsPublic(entity)
+
+	private def IsPublic(entity as IEntity) as bool:
+		member = entity as IMember
+		return member is null or member.IsPublic

--- a/tests/Boo.Lang.Interpreter.Tests/CodeCompletionTestFixture.boo
+++ b/tests/Boo.Lang.Interpreter.Tests/CodeCompletionTestFixture.boo
@@ -1,0 +1,92 @@
+namespace Boo.Lang.Interpreter.Tests
+
+import System.Collections.Generic
+import Boo.Lang.Compiler
+import Boo.Lang.Compiler.Ast
+import Boo.Lang.Compiler.IO
+import Boo.Lang.Compiler.Pipelines
+import Boo.Lang.Compiler.TypeSystem
+import Boo.Lang.Environments
+import Boo.Lang.Interpreter
+import NUnit.Framework
+
+[TestFixture]
+class CodeCompletionTestFixture:
+"""
+What the marker resolves to, and which of its members are worth offering.
+
+The suggestions are taken straight from CodeCompletion rather than through an
+interpreter, because an interpreter always asks without a scope.
+"""
+
+	private static final Inside = """
+class Greeter:
+	public def Pub():
+		pass
+
+	private def Priv():
+		pass
+
+	protected def Prot():
+		pass
+
+	def Use():
+		self.__codecomplete__
+"""
+
+	private static final Outside = """
+class Greeter:
+	public def Pub():
+		pass
+
+	private def Priv():
+		pass
+
+	protected def Prot():
+		pass
+
+class Other:
+	def Use(g as Greeter):
+		g.__codecomplete__
+"""
+
+	private def Resolve(code as string):
+		compiler = BooCompiler()
+		pipeline = ResolveExpressions(BreakOnErrors: false)
+		pipeline.Add(FindCodeCompleteSuggestion())
+		compiler.Parameters.Pipeline = pipeline
+		compiler.Parameters.Input.Add(StringInput("completion", code))
+		return compiler.Run()
+
+	private def Offered(code as string, scoped as bool) as List[of string]:
+		result = Resolve(code)
+		entity = result["suggestion"] as IEntity
+		assert entity is not null, "the marker resolved to nothing"
+		scope as TypeDefinition
+		scope = result["scope"] as TypeDefinition if scoped
+		names = List[of string]()
+		# Inside the compiler's environment, which resolving a member needs.
+		ActiveEnvironment.With(result.Environment) do:
+			for item in CodeCompletion.SuggestionsFor(entity, false, scope):
+				names.Add(item.Name)
+		return names
+
+	[Test]
+	def OffersWhatTheCursorCanReachFromInsideTheClass():
+		names = Offered(Inside, true)
+		assert "Pub" in names
+		assert "Priv" in names
+		assert "Prot" in names
+
+	[Test]
+	def HidesWhatTheCursorCannotReachFromAnotherClass():
+		names = Offered(Outside, true)
+		assert "Pub" in names
+		assert "Priv" not in names
+		assert "Prot" not in names
+
+	[Test]
+	def OffersOnlyThePublicSurfaceWithoutAScope():
+		names = Offered(Inside, false)
+		assert "Pub" in names
+		assert "Priv" not in names


### PR DESCRIPTION
Splits code completion out of `AbstractInterpreter` and gives it a
way to know where the cursor is.

`FilterSuggestions` and its helpers were private members of
`AbstractInterpreter`, and filtered on `IsPublic` alone. That is right
for an interpreter prompt, which is always outside the type it is asking
about, but it hides everything a caller inside the type can reach.

- `CodeCompletion` holds the filtering; `FindCodeCompleteSuggestion` moves alongside it
- members are filtered through `IAccessibilityChecker`, so an internal, private or protected member is offered where it is reachable
- `FindCodeCompleteSuggestion` records the enclosing `TypeDefinition` as `_context["scope"]`
- without a scope the checker is `AccessibilityChecker.Global`, so the interpreter behaves exactly as before

`CodeCompletionTestFixture` asks for suggestions three ways: from inside the class, from another class, and with no scope. Inside offers `Priv` and `Prot`, the other two do not. That difference is what the scope argument gives us.

Two things worth mentioning:

- `FindCodeCompleteSuggestion` was nested in `AbstractInterpreter`, so
 this renames it to `Boo.Lang.Interpreter.FindCodeCompleteSuggestion`.
- `IsSpecial` is public with no caller here. The language server needs it, so it looks like it is unnecessary, but it's not

