### PR TITLE
fix(Compiler): fix async await crashes in loops and handlers

### DIFF
--- a/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
+++ b/src/Boo.Lang.Compiler/CompilerErrorFactory.cs
@@ -1050,6 +1050,11 @@ namespace Boo.Lang.Compiler
             return Instantiate("BCE0180", n, t);
         }
 
+        public static CompilerError AwaitInFilteredCatchWithExceptionVariable(Node anchor, string name)
+        {
+            return Instantiate("BCE0195", anchor, name);
+        }
+
 	    public static CompilerError UnsafeReturnInAsync(Expression e)
 	    {
 	        return Instantiate("BCE0181", e);

--- a/src/Boo.Lang.Compiler/Steps/AsyncAwait/AsyncExceptionHandlerRewriter.cs
+++ b/src/Boo.Lang.Compiler/Steps/AsyncAwait/AsyncExceptionHandlerRewriter.cs
@@ -472,7 +472,7 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
             _currentAwaitCatchFrame = null;
 
             Visit(node.ExceptionHandlers);
-            Statement tryWithCatches = new TryStatement{EnsureBlock = rewrittenTry};
+            Statement tryWithCatches = new TryStatement{ProtectedBlock = rewrittenTry};
             ((TryStatement)tryWithCatches).ExceptionHandlers = node.ExceptionHandlers;
 
             var currentAwaitCatchFrame = _currentAwaitCatchFrame;
@@ -518,10 +518,29 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
                 var result = Visit(node);
                 _currentAwaitCatchFrame = origCurrentAwaitCatchFrame;
                 ReplaceCurrentNode(result);
+                return;
             }
 
             var currentAwaitCatchFrame = _currentAwaitCatchFrame ??
                 (_currentAwaitCatchFrame = new AwaitCatchFrame(_tss, _F, _containingMethod));
+
+            // The handler body moves out of the catch, so the declared exception is an
+            // ordinary local from here on and has to survive the awaits in that body.
+            if (node.FilterCondition == null && node.Declaration != null)
+            {
+                var declaredException = node.Declaration.Entity as InternalLocal;
+                if (declaredException != null)
+                    declaredException.OriginalDeclaration = null;
+            }
+            // A filtered handler keeps its exception on the frame, where an await in
+            // the body does not preserve it.
+            else if (node.FilterCondition != null && node.Declaration != null
+                     && !string.IsNullOrEmpty(node.Declaration.Name))
+            {
+                CompilerContext.Current.Errors.Add(
+                    CompilerErrorFactory.AwaitInFilteredCatchWithExceptionVariable(
+                        node.Declaration, node.Declaration.Name));
+            }
 
             var catchType = node.Declaration != null ? (IType)node.Declaration.Type.Entity : _tss.ObjectType;
             var catchTemp = _F.DeclareTempLocal(_containingMethod, catchType);
@@ -554,6 +573,7 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
                         new ExpressionStatement(storePending),
                         new ExpressionStatement(setPendingCatchNum))
                 };
+                catchTemp.OriginalDeclaration = catchAndPend.Declaration;
                 // catch locals live on the synthetic catch handler block
             }
             else
@@ -587,6 +607,7 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
                     FilterCondition = newFilter,
                     Block = new Block(new ExpressionStatement(setPendingCatchNum))
                 };
+                catchTemp.OriginalDeclaration = catchAndPend.Declaration;
             }
             if (node.ContainsAnnotation("isSynthesizedAsyncCatchAll"))
                 catchAndPend.Annotate("isSynthesizedAsyncCatchAll");
@@ -644,6 +665,7 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
             if (catchFrame == null || !catchFrame.TryGetHoistedLocal((InternalLocal)node.Entity, out hoistedLocal))
             {
                 base.OnDeclaration(node);
+                return;
             }
 
             ReplaceCurrentNode(new Declaration(node.Name, _F.CreateTypeReference(hoistedLocal.Type)) {Entity = hoistedLocal});
@@ -654,6 +676,7 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
             if (node.Exception != null || _currentAwaitCatchFrame == null)
             {
                 base.OnRaiseStatement(node);
+                return;
             }
 
             ReplaceCurrentNode(Rethrow(_currentAwaitCatchFrame.pendingCaughtException));

--- a/src/Boo.Lang.Compiler/Steps/AsyncAwait/AwaitExpressionSpiller.cs
+++ b/src/Boo.Lang.Compiler/Steps/AsyncAwait/AwaitExpressionSpiller.cs
@@ -508,6 +508,44 @@ namespace Boo.Lang.Compiler.Steps.AsyncAwait
 			    UpdateConditionalStatement(node);
 	    }
 
+		public override void OnWhileStatement(WhileStatement node)
+		{
+			base.OnWhileStatement(node);
+			if (node.Condition.NodeType != SpillSequenceBuilder)
+				return;
+
+			// A while condition is evaluated on every pass, so what it spills
+			// belongs at the top of the body rather than ahead of the loop.
+			var builder = (BoundSpillSequenceBuilder) node.Condition;
+			var body = new Block(node.Block.LexicalInfo);
+			foreach (var spilled in builder.GetStatements())
+				body.Add(spilled);
+
+			// or and then run when the condition fails, so they move to the branch
+			// that replaces it.
+			var orBlock = node.OrBlock;
+			var thenBlock = node.ThenBlock;
+			node.OrBlock = null;
+			node.ThenBlock = null;
+			var conditionFailed = new Block(node.LexicalInfo);
+			if (orBlock != null)
+				conditionFailed.Add(orBlock);
+			if (thenBlock != null)
+				conditionFailed.Add(thenBlock);
+			conditionFailed.Add(new BreakStatement(node.LexicalInfo));
+
+			body.Add(new IfStatement(
+				node.LexicalInfo,
+				_F.CreateNotExpression(builder.Value),
+				conditionFailed,
+				null));
+			foreach (var statement in node.Block.Statements)
+				body.Add(statement);
+
+			node.Condition = _F.CreateBoolLiteral(true);
+			node.Block = body;
+		}
+
 	    #endregion
 
         #region Expression Visitors

--- a/src/Boo.Lang.Compiler/Steps/StateMachine/MethodToStateMachineTransformer.cs
+++ b/src/Boo.Lang.Compiler/Steps/StateMachine/MethodToStateMachineTransformer.cs
@@ -296,6 +296,7 @@ namespace Boo.Lang.Compiler.Steps.StateMachine
         public override void OnReferenceExpression(ReferenceExpression node)
         {
             InternalField mapped;
+            IEntity remapped;
             if (_mapping.TryGetValue(node.Entity, out mapped))
             {
                 ReplaceCurrentNode(
@@ -303,6 +304,12 @@ namespace Boo.Lang.Compiler.Steps.StateMachine
                         node.LexicalInfo,
                         CodeBuilder.CreateSelfReference(_stateMachineClass.Entity),
                         mapped));
+            }
+            // Handler variables stay locals of MoveNext, so their references follow
+            // the same map their declaration does.
+            else if (_entityMapper.TryGetValue(node.Entity, out remapped))
+            {
+                node.Entity = remapped;
             }
 			else if (node.Entity is IGenericMappedMember || node.Entity is IGenericParameter || node.Entity is InternalLocal)
 			{
@@ -504,8 +511,15 @@ namespace Boo.Lang.Compiler.Steps.StateMachine
 				ContextAnnotations.AddFieldInvocation(node);
 			else if (node.Target.Entity.EntityType == EntityType.BuiltinFunction)
 			{
+				// default's type comes from the typeof argument, not that argument's own System.Type.
 				if (node.Target.Entity == BuiltinFunction.Default)
-					node.ExpressionType = node.Arguments[0].ExpressionType;
+				{
+					var typeofArgument = node.Arguments.Count > 0
+						? node.Arguments[0] as TypeofExpression
+						: null;
+					if (typeofArgument != null)
+						node.ExpressionType = (IType)typeofArgument.Type.Entity;
+				}
 			}
 			if (et != null && 
 				((et.GenericInfo != null || 

--- a/src/Boo.Lang/Resources/StringResources.cs
+++ b/src/Boo.Lang/Resources/StringResources.cs
@@ -197,6 +197,7 @@ namespace Boo.Lang.Resources
 		public const string BCE0192 = "Byref-like type '{0}' cannot be captured by a closure, a generator or an async method.";
 		public const string BCE0193 = "Byref-like type '{0}' cannot be the element type of an array.";
 		public const string BCE0194 = "Byref-like type '{0}' cannot be used as a generic argument.";
+		public const string BCE0195 = "Exception variable '{0}' cannot be used in a filtered catch block that awaits.";
         public const string BCW0000 = "WARNING: {0}";
 		public const string BCW0001 = "WARNING: Type '{0}' does not provide an implementation for '{1}' and will be marked abstract.";
 		public const string BCW0002 = "WARNING: Statement modifiers have no effect in labels.";

--- a/tests/BooCompiler.Tests/Generated/AsyncTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/AsyncTestFixture.generated.boo
@@ -41,6 +41,14 @@ partial class AsyncTestFixture:
 		RunCompilerTestCase("await-in-using-and-for.boo")
 
 	[Test]
+	def @await_in_while_condition():
+		RunCompilerTestCase("await-in-while-condition.boo")
+
+	[Test]
+	def @await_in_while_condition_or_then():
+		RunCompilerTestCase("await-in-while-condition-or-then.boo")
+
+	[Test]
 	def @await_switch():
 		RunCompilerTestCase("await-switch.boo")
 

--- a/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/CompilerErrorsTestFixture.generated.boo
@@ -926,6 +926,10 @@ class CompilerErrorsTestFixture(AbstractCompilerErrorsTestFixture):
 		RunCompilerTestCase("BCE0188-1.boo")
 
 	[Test]
+	def @BCE0195_1():
+		RunCompilerTestCase("BCE0195-1.boo")
+
+	[Test]
 	def @CannotConvertFooToInt():
 		RunCompilerTestCase("CannotConvertFooToInt.boo")
 

--- a/tests/testcases/async/await-in-while-condition-or-then.boo
+++ b/tests/testcases/async/await-in-while-condition-or-then.boo
@@ -1,0 +1,28 @@
+"""
+1
+0
+then
+never entered
+then
+"""
+import System.Threading.Tasks
+
+class Counter:
+	public n as int
+
+	[async] def StepAsync() as Task[of bool]:
+		await Task.Delay(1)
+		n--
+		return n >= 0
+
+[async] def DrainAsync(start as int) as Task:
+	c = Counter(n: start)
+	while await(c.StepAsync()):
+		print c.n
+	or:
+		print "never entered"
+	then:
+		print "then"
+
+DrainAsync(2).Wait()
+DrainAsync(0).Wait()

--- a/tests/testcases/async/await-in-while-condition.boo
+++ b/tests/testcases/async/await-in-while-condition.boo
@@ -1,0 +1,21 @@
+"""
+2
+1
+0
+"""
+import System.Threading.Tasks
+
+class Counter:
+	public n = 3
+
+	[async] def StepAsync() as Task[of bool]:
+		await Task.Delay(1)
+		n--
+		return n >= 0
+
+[async] def DrainAsync(c as Counter) as Task:
+	while await(c.StepAsync()):
+		print c.n
+
+counter = Counter()
+DrainAsync(counter).Wait()

--- a/tests/testcases/errors/BCE0195-1.boo
+++ b/tests/testcases/errors/BCE0195-1.boo
@@ -1,0 +1,12 @@
+"""
+BCE0195-1.boo(10,17): BCE0195: Exception variable 'e' cannot be used in a filtered catch block that awaits.
+"""
+import System
+import System.Threading.Tasks
+
+[async] def Run() as Task:
+	try:
+		raise InvalidOperationException("boom")
+	except e as Exception if e.Message == "boom":
+		await Task.Delay(1)
+		print e.Message


### PR DESCRIPTION
Fixes several ways an `await` could crash the compiler or produce bad IL.

| Case | Before | After |
|---|---|---|
| `await` in a `while` condition | ICE `Should be unreachable` | works |
| ...combined with `or:` / `then:` | ICE | works |
| Named exception variable read after an `await` in `except` | ICE | works |
| ...in a *filtered* `except` | ICE | `BCE0195` |

Also fixed along the way:

- the rewritten `try` was built with `EnsureBlock` instead of `ProtectedBlock`, so catch handlers hung off a try with no protected body
- `default(T)` inside a state machine took its type from the `typeof` argument's own `System.Type` rather than the type that argument names, which broke `IsGenericDefaultInvocation`
- three handler rewrites fell through after their base visit and dereferenced a null hoisted local

A `while` condition is re-evaluated on every pass, so what it spills belongs at the top of the loop body, not ahead of the loop. `or:` and `then:` move into the branch that replaces the condition test, which preserves their semantics: `or:` runs when the body never executed, `then:` on normal exit, and a `break` in the body skips both.

`await` inside `ensure:` still fails to compile, exactly as it does on `main`. The pending-exception local has to become a field to survive a suspension in the finally body; that is a larger change and is left for a follow-up, along with the filtered-catch case that `BCE0195` currently rejects.
