### PR TITLE
fix(compiler): fill defaults skipped by named args

### DIFF
--- a/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
+++ b/src/Boo.Lang.Compiler/Steps/ProcessMethodBodies.cs
@@ -4488,11 +4488,20 @@ namespace Boo.Lang.Compiler.Steps
 
 			WithdrawLocalsDeclaredByNamedArguments(node);
 
+			var last = positional.Length - 1;
+			while (last >= 0 && positional[last] == null)
+				--last;
+
 			node.Arguments.Clear();
-			foreach (var argument in positional)
+			for (var i = 0; i <= last; ++i)
 			{
+				// A hole before a supplied argument takes its default here; one
+				// after the last is left to FillOmittedArguments.
+				var argument = positional[i];
+				if (argument == null && parameters[i].HasDefaultValue)
+					argument = CreateDefaultValueLiteral(node.LexicalInfo, parameters[i]);
 				if (argument == null)
-					break;
+					return;
 				node.Arguments.Add(argument);
 			}
 		}

--- a/tests/BooCompiler.Tests/Generated/OptionalParametersIntegrationTestFixture.generated.boo
+++ b/tests/BooCompiler.Tests/Generated/OptionalParametersIntegrationTestFixture.generated.boo
@@ -26,6 +26,10 @@ class OptionalParametersIntegrationTestFixture(AbstractCompilerTestCase):
 		RunCompilerTestCase("exact-overload-preferred.boo")
 
 	[Test]
+	def @named_argument_skips_default():
+		RunCompilerTestCase("named-argument-skips-default.boo")
+
+	[Test]
 	def @omitted_argument_still_runs():
 		RunCompilerTestCase("omitted-argument-still-runs.boo")
 

--- a/tests/testcases/integration/optional-parameters/named-argument-skips-default.boo
+++ b/tests/testcases/integration/optional-parameters/named-argument-skips-default.boo
@@ -1,0 +1,16 @@
+"""
+a=1 b=9
+a=1 b=2 c=9
+a=7 b=2 c=9
+"""
+def two(a as int = 1, b as int = 2) as string:
+	return "a=$a b=$b"
+
+def three(a as int = 1, b as int = 2, c as int = 3) as string:
+	return "a=$a b=$b c=$c"
+
+# A named argument that skips an earlier default leaves a hole before it.
+# This test tells us whether the hole gets its default and the name its value.
+print two(b=9)
+print three(c=9)
+print three(7, c=9)


### PR DESCRIPTION
This PR fixes a bug with named args

- Give each hole before the last supplied argument its default
- Add optional-parameters testcase for a name that skips a defaultx